### PR TITLE
Refactor Edge representation and update RailNetwork API

### DIFF
--- a/includes/Edge.hpp
+++ b/includes/Edge.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <memory>
+
+class Node;	 // forward declaration
+
+struct Edge
+{
+		std::weak_ptr<Node> node;
+		size_t				distance;
+		size_t				speedLimit;
+};

--- a/includes/Node.hpp
+++ b/includes/Node.hpp
@@ -6,7 +6,7 @@
 /*   By: andrefrancisco <andrefrancisco@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 20:36:48 by andrefranci       #+#    #+#             */
-/*   Updated: 2025/05/18 00:38:28 by andrefranci      ###   ########.fr       */
+/*   Updated: 2025/05/18 16:40:16 by andrefranci      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,8 @@ class Node
 		Node &operator=(const Node &src) = delete;
 		Node &operator=(Node &&src) = delete;
 
-		void addEdge(std::weak_ptr<Node> node, size_t distance, size_t speedLimit);
+		void			   addEdge(std::weak_ptr<Node> node, size_t distance,
+								   size_t speedLimit);
 		const std::string &getName() const;
 		const std::vector<Edge> &getEdges() const;
 
@@ -62,13 +63,33 @@ class Node
 				}
 		};
 
-		// Custom exception class for duplicate node
-		class DuplicateNodeException : public std::runtime_error
+		// Custom exception class for duplicate node or invalid node name
+		class InvalidNodeException : public std::runtime_error
 		{
 			public:
-				DuplicateNodeException(const std::string &nodeName)
-					: std::runtime_error("Error: Node already exists: "
-										 + nodeName)
+				InvalidNodeException(const std::string &nodeName,
+									 bool				isNull = false)
+					: std::runtime_error(
+						isNull
+							? "Error: Node name is null."
+							: (nodeName.empty()
+								   ? "Error: Node name cannot be empty."
+								   : "Error: Node already exists: " + nodeName))
+				{
+				}
+		};
+
+		// Custom exception class for invalid edge parameters (distance, speed,
+		// etc.)
+		class InvalidEdgeException : public std::runtime_error
+		{
+			public:
+				InvalidEdgeException(const std::string &nodeName,
+									 const std::string &targetNodeName,
+									 const std::string &reason)
+					: std::runtime_error("Error: Invalid edge from node '"
+										 + nodeName + "' to '" + targetNodeName
+										 + "': " + reason)
 				{
 				}
 		};

--- a/includes/Node.hpp
+++ b/includes/Node.hpp
@@ -6,13 +6,14 @@
 /*   By: andrefrancisco <andrefrancisco@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 20:36:48 by andrefranci       #+#    #+#             */
-/*   Updated: 2025/05/17 17:49:53 by andrefranci      ###   ########.fr       */
+/*   Updated: 2025/05/18 00:38:28 by andrefranci      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef NODE_HPP
 #define NODE_HPP
 
+#include "Edge.hpp"
 #include "libraries.hpp"
 
 class Node
@@ -21,18 +22,6 @@ class Node
 		// Static set to keep track of existing node names
 		static std::unordered_set<std::string> _existingNames;
 		std::string							   _name;
-
-		// Represents a connection (edge) between two nodes in the graph.
-		// Fields:
-		// - node: A weak pointer to the connected node.
-		// - distance: The distance to the connected node (in meters).
-		// - speedLimit: The speed limit on the edge (in kilometers per hour).
-		struct Edge
-		{
-				std::weak_ptr<Node> node;
-				size_t				distance;
-				size_t				speedLimit;
-		};
 
 		// Vector to store edges
 		std::vector<Edge> _edges;
@@ -46,8 +35,7 @@ class Node
 		Node &operator=(const Node &src) = delete;
 		Node &operator=(Node &&src) = delete;
 
-		void			   addEdge(std::weak_ptr<Node> node, size_t distance,
-								   size_t speedLimit);
+		void addEdge(std::weak_ptr<Node> node, size_t distance, size_t speedLimit);
 		const std::string &getName() const;
 		const std::vector<Edge> &getEdges() const;
 

--- a/includes/RailNetwork.hpp
+++ b/includes/RailNetwork.hpp
@@ -6,7 +6,7 @@
 /*   By: andrefrancisco <andrefrancisco@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/15 21:54:26 by andrefranci       #+#    #+#             */
-/*   Updated: 2025/03/08 12:03:27 by andrefranci      ###   ########.fr       */
+/*   Updated: 2025/05/18 00:38:30 by andrefranci      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+#include "Edge.hpp"
 #include "Node.hpp"
 #include "Singleton.hpp"
 #include "libraries.hpp"
@@ -25,13 +26,9 @@
 class RailNetwork : public Singleton<RailNetwork>
 {
 	private:
-		// Adjacency list representation of the rail network
-		// The key is a shared pointer to a node and the value is a vector of
-		// pairs The pair contains a shared pointer to a node and the distance
-		// between the two nodes
-		using AdjacencyList = std::unordered_map<
-			std::shared_ptr<Node>,
-			std::vector<std::pair<std::shared_ptr<Node>, size_t>>>;
+		// Use Node::Edge for adjacency list
+		using AdjacencyList
+			= std::unordered_map<std::shared_ptr<Node>, std::vector<Edge>>;
 		AdjacencyList _adjacencyList;
 
 	public:
@@ -40,11 +37,12 @@ class RailNetwork : public Singleton<RailNetwork>
 
 		// Add a connection between two nodes in the rail network
 		void addConnection(std::shared_ptr<Node> node1,
-						   std::shared_ptr<Node> node2, size_t distance);
+						   std::shared_ptr<Node> node2, size_t distance,
+						   size_t speedLimit);
 
 		// Get the neighbors of a node
-		const std::vector<std::pair<std::shared_ptr<Node>, size_t>>
-			&getNeighbours(std::shared_ptr<Node> node) const;
+		const std::vector<Edge> &getNeighbours(
+			std::shared_ptr<Node> node) const;
 
 		// Get all nodes in the rail network
 		const std::vector<std::shared_ptr<Node>> getNodes() const;

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -43,7 +43,7 @@ void Node::addEdge(std::weak_ptr<Node> node, size_t distance, size_t speedLimit)
 	}
 
 	// Check if the edge already exists
-	for (const Node::Edge &edge : _edges)
+	for (const Edge &edge : _edges)
 	{
 		auto existingNode = edge.node.lock();
 		if (existingNode && existingNode == sharedNode)
@@ -62,7 +62,7 @@ const std::string &Node::getName() const
 }
 
 // Get the edges of the node
-const std::vector<Node::Edge> &Node::getEdges() const
+const std::vector<Edge> &Node::getEdges() const
 {
 	return _edges;
 }

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -6,7 +6,7 @@
 /*   By: andrefrancisco <andrefrancisco@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 21:11:20 by andrefranci       #+#    #+#             */
-/*   Updated: 2025/05/17 17:50:29 by andrefranci      ###   ########.fr       */
+/*   Updated: 2025/05/18 16:46:36 by andrefranci      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,9 +17,10 @@ std::unordered_set<std::string> Node::_existingNames;
 // Parameterized constructor
 Node::Node(std::string name) : _name(name)
 {
-	if (_existingNames.find(name) != _existingNames.end())
+	// Check if the name is empty or already exists
+	if (name.empty() || _existingNames.find(name) != _existingNames.end())
 	{
-		throw DuplicateNodeException(name);
+		throw InvalidNodeException(name);
 	}
 	_existingNames.insert(name);
 }
@@ -27,6 +28,50 @@ Node::Node(std::string name) : _name(name)
 // Destructor
 Node::~Node()
 {
+}
+
+static void isEdgeValid(const std::string &nodeName,
+						const std::string &targetName, size_t distance,
+						size_t speedLimit)
+{
+	if (reinterpret_cast<const std::make_signed<size_t>::type &>(distance) < 0)
+	{
+		throw Node::InvalidEdgeException(
+			nodeName, targetName,
+			std::string(
+				"Distance value is negative (was likely passed as a negative ")
+				+ "number and cast to size_t)."
+				+ " Please provide a positive value in the range: 1 to "
+				+ std::to_string(std::numeric_limits<size_t>::max()) + ".");
+	}
+
+	if (reinterpret_cast<const std::make_signed<size_t>::type &>(speedLimit)
+		< 0)
+	{
+		throw Node::InvalidEdgeException(
+			nodeName, targetName,
+			std::string("Speed limit value is negative (was likely passed as a "
+						"negative ")
+				+ "number and cast to size_t)."
+				+ " Please provide a positive value in the range: 1 to "
+				+ std::to_string(std::numeric_limits<size_t>::max()) + ".");
+	}
+	if (distance == 0)
+	{
+		throw Node::InvalidEdgeException(
+			nodeName, targetName,
+			std::string("Distance value (") + std::to_string(distance)
+				+ ") is zero. Acceptable range: 1 to "
+				+ std::to_string(std::numeric_limits<size_t>::max()) + ".");
+	}
+	if (speedLimit == 0)
+	{
+		throw Node::InvalidEdgeException(
+			nodeName, targetName,
+			std::string("Speed limit value (") + std::to_string(speedLimit)
+				+ ") is zero. Acceptable range: 1 to "
+				+ std::to_string(std::numeric_limits<size_t>::max()) + ".");
+	}
 }
 
 // Add an edge to the node
@@ -52,6 +97,10 @@ void Node::addEdge(std::weak_ptr<Node> node, size_t distance, size_t speedLimit)
 											 sharedNode->getName());
 		}
 	}
+
+	isEdgeValid(this->_name, sharedNode ? sharedNode->getName() : "unknown",
+				distance, speedLimit);
+
 	_edges.push_back({node, distance, speedLimit});
 }
 

--- a/src/RailNetwork.cpp
+++ b/src/RailNetwork.cpp
@@ -21,10 +21,10 @@ void RailNetwork::addNode(std::shared_ptr<Node> node)
 	}
 }
 
-// Add a connection (edge) between two nodes with a specific distance and speed limit
+// Add a connection (edge) between two nodes with a specific distance and speed
+// limit
 void RailNetwork::addConnection(std::shared_ptr<Node> node1,
-								std::shared_ptr<Node> node2,
-								size_t distance,
+								std::shared_ptr<Node> node2, size_t distance,
 								size_t speedLimit)
 {
 	if (node1 == node2)
@@ -57,8 +57,8 @@ void RailNetwork::addConnection(std::shared_ptr<Node> node1,
 }
 
 // Get the neighbors of a node
-const std::vector<Edge>
-	&RailNetwork::getNeighbours(std::shared_ptr<Node> node) const
+const std::vector<Edge> &RailNetwork::getNeighbours(
+	std::shared_ptr<Node> node) const
 {
 	auto it = _adjacencyList.find(node);
 	if (it != _adjacencyList.end())

--- a/tests/NodeTest.cpp
+++ b/tests/NodeTest.cpp
@@ -6,7 +6,7 @@
 /*   By: andrefrancisco <andrefrancisco@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/24 18:23:49 by andrefranci       #+#    #+#             */
-/*   Updated: 2025/05/17 16:52:50 by andrefranci      ###   ########.fr       */
+/*   Updated: 2025/05/18 16:40:20 by andrefranci      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 #include <iostream>
 #include <memory>
 
+#include "../includes/Edge.hpp"	 // Include the Edge header
 #include "../includes/Node.hpp"
-#include "../includes/Edge.hpp" // Include the Edge header
 #include "../includes/colours.hpp"	// Include the colours header
 
 bool testAddEdges()
@@ -193,11 +193,11 @@ bool testDuplicateNode()
 		{
 			std::shared_ptr<Node> nodeDuplicate = std::make_shared<Node>("A4");
 			std::cerr << RED
-					  << "Error: Expected DuplicateNodeException not thrown"
+					  << "Error: Expected InvalidNodeException not thrown"
 					  << RESET << std::endl;
 			testPassed = false;
 		}
-		catch (const Node::DuplicateNodeException &e)
+		catch (const Node::InvalidNodeException &e)
 		{
 			std::cerr << GREEN << "Caught expected exception: " << e.what()
 					  << RESET << std::endl;
@@ -214,6 +214,417 @@ bool testDuplicateNode()
 	}
 
 	return (testPassed);
+}
+
+bool testInvalidEdgeZeroDistance()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeZeroDistance..." << RESET
+			  << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A6a");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B6a");
+		try
+		{
+			nodeA->addEdge(nodeB, 0, 50);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for zero "
+						 "distance not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN << "Caught expected exception (zero distance): "
+					  << e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED
+				  << "Exception in testInvalidEdgeZeroDistance: " << e.what()
+				  << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeZeroSpeed()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeZeroSpeed..." << RESET
+			  << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A6b");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B6b");
+		try
+		{
+			nodeA->addEdge(nodeB, 10, 0);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for zero speed "
+						 "limit not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN
+					  << "Caught expected exception (zero speed): " << e.what()
+					  << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED
+				  << "Exception in testInvalidEdgeZeroSpeed: " << e.what()
+				  << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeNegativeDistance()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeNegativeDistance..." << RESET
+			  << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A6c");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B6c");
+		try
+		{
+			nodeA->addEdge(nodeB, -10, 50);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for negative "
+						 "distance not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN
+					  << "Caught expected exception (negative distance): "
+					  << e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED << "Exception in testInvalidEdgeNegativeDistance: "
+				  << e.what() << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeNegativeSpeed()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeNegativeSpeed..." << RESET
+			  << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A6d");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B6d");
+		try
+		{
+			nodeA->addEdge(nodeB, 10, -10);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for negative "
+						 "speed limit not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN << "Caught expected exception (negative speed): "
+					  << e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED
+				  << "Exception in testInvalidEdgeNegativeSpeed: " << e.what()
+				  << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeDistanceOverflow()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeDistanceOverflow..." << RESET
+			  << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A6e");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B6e");
+		try
+		{
+			volatile size_t overflow = std::numeric_limits<size_t>::max();
+			overflow++;
+			nodeA->addEdge(nodeB, overflow, 50);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for distance "
+						 "overflow not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN
+					  << "Caught expected exception (distance overflow): "
+					  << e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED << "Exception in testInvalidEdgeDistanceOverflow: "
+				  << e.what() << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeSpeedOverflow()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeSpeedOverflow..." << RESET
+			  << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A6f");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B6f");
+		try
+		{
+			volatile size_t overflow = std::numeric_limits<size_t>::max();
+			overflow++;
+			nodeA->addEdge(nodeB, 10, overflow);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for speed limit "
+						 "overflow not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN << "Caught expected exception (speed overflow): "
+					  << e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED
+				  << "Exception in testInvalidEdgeSpeedOverflow: " << e.what()
+				  << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeVeryNegativeDistance()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeVeryNegativeDistance..."
+			  << RESET << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A8a");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B8a");
+		try
+		{
+			// Use a very negative value, e.g., INT64_MIN
+			nodeA->addEdge(nodeB, static_cast<size_t>(INT64_MIN), 50);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for very "
+						 "negative distance not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN
+					  << "Caught expected exception (very negative distance): "
+					  << e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED << "Exception in testInvalidEdgeVeryNegativeDistance: "
+				  << e.what() << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeVeryNegativeSpeed()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeVeryNegativeSpeed..."
+			  << RESET << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A8b");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B8b");
+		try
+		{
+			nodeA->addEdge(nodeB, 10, static_cast<size_t>(INT64_MIN));
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for very "
+						 "negative speed not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr << GREEN
+					  << "Caught expected exception (very negative speed): "
+					  << e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED << "Exception in testInvalidEdgeVeryNegativeSpeed: "
+				  << e.what() << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testInvalidEdgeVeryLargeNegativeDistance()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testInvalidEdgeVeryLargeNegativeDistance..."
+			  << RESET << std::endl;
+	bool testPassed = true;
+	try
+	{
+		std::shared_ptr<Node> nodeA = std::make_shared<Node>("A9a");
+		std::shared_ptr<Node> nodeB = std::make_shared<Node>("B9a");
+		try
+		{
+			// Use a very large negative value as a string literal and convert
+			// to long double, then to size_t
+			const char *bigNegStr
+				= "-10000000000000000000000000000000000000000000000000000000000"
+				  "000000000000000000000000000000000000000000000000000000000000"
+				  "000000000000000000000000000000000000000000000000000000000000"
+				  "000000000000000000000000000000000000000000000000000000000000"
+				  "000000000000000000000000000000000000000000000000000000000000"
+				  "000000000000000000000000000000000000000000000000000000000000"
+				  "00000000000000000000000";
+			long double bigNeg = std::strtold(bigNegStr, nullptr);
+			size_t		val = static_cast<size_t>(bigNeg);
+			nodeA->addEdge(nodeB, val, 50);
+			std::cerr << RED
+					  << "Error: Expected InvalidEdgeException for very large "
+						 "negative distance not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidEdgeException &e)
+		{
+			std::cerr
+				<< GREEN
+				<< "Caught expected exception (very large negative distance): "
+				<< e.what() << RESET << std::endl;
+		}
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED
+				  << "Exception in testInvalidEdgeVeryLargeNegativeDistance: "
+				  << e.what() << RESET << std::endl;
+		testPassed = false;
+	}
+	return testPassed;
+}
+
+bool testAddNodeWithNullName()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testAddNodeWithNullName..." << RESET
+			  << std::endl;
+
+	bool testPassed = true;
+
+	try
+	{
+		const char *nullName = nullptr;
+		try
+		{
+			// This will cause undefined behavior, but for the sake of the test:
+			std::shared_ptr<Node> nodeNull = std::make_shared<Node>(
+				nullName ? std::string(nullName) : std::string());
+			std::cerr << RED
+					  << "Error: Expected InvalidNodeException not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidNodeException &e)
+		{
+			std::cerr << GREEN << "Caught expected exception: " << e.what()
+					  << RESET << std::endl;
+		}
+		std::cout << GREEN << "testAddNodeWithNullName completed." << RESET
+				  << std::endl;
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED << "Exception in testAddNodeWithNullName: " << e.what()
+				  << RESET << std::endl;
+		testPassed = false;
+	}
+
+	return testPassed;
+}
+
+bool testAddNodeWithEmptyName()
+{
+	std::cout << YELLOW << "-----------------------" << RESET << std::endl;
+	std::cout << YELLOW << "Running testAddNodeWithEmptyName..." << RESET
+			  << std::endl;
+
+	bool testPassed = true;
+
+	try
+	{
+		try
+		{
+			std::shared_ptr<Node> nodeEmpty = std::make_shared<Node>("");
+			std::cerr << RED
+					  << "Error: Expected InvalidNodeException not thrown"
+					  << RESET << std::endl;
+			testPassed = false;
+		}
+		catch (const Node::InvalidNodeException &e)
+		{
+			std::cerr << GREEN << "Caught expected exception: " << e.what()
+					  << RESET << std::endl;
+		}
+		std::cout << GREEN << "testAddNodeWithEmptyName completed." << RESET
+				  << std::endl;
+	}
+	catch (const std::exception &e)
+	{
+		std::cerr << RED
+				  << "Exception in testAddNodeWithEmptyName: " << e.what()
+				  << RESET << std::endl;
+		testPassed = false;
+	}
+
+	return testPassed;
 }
 
 void printNodeEdges(const std::shared_ptr<Node> &node)
@@ -240,6 +651,17 @@ int main(void)
 	allTestsPassed &= testDuplicateEdge();
 	allTestsPassed &= testSelfEdge();
 	allTestsPassed &= testDuplicateNode();
+	allTestsPassed &= testInvalidEdgeZeroDistance();
+	allTestsPassed &= testInvalidEdgeZeroSpeed();
+	allTestsPassed &= testInvalidEdgeNegativeDistance();
+	allTestsPassed &= testInvalidEdgeNegativeSpeed();
+	allTestsPassed &= testInvalidEdgeDistanceOverflow();
+	allTestsPassed &= testInvalidEdgeSpeedOverflow();
+	allTestsPassed &= testInvalidEdgeVeryNegativeDistance();
+	allTestsPassed &= testInvalidEdgeVeryNegativeSpeed();
+	allTestsPassed &= testInvalidEdgeVeryLargeNegativeDistance();
+	allTestsPassed &= testAddNodeWithNullName();
+	allTestsPassed &= testAddNodeWithEmptyName();
 
 	// Create nodes for printing edges
 	std::shared_ptr<Node> nodeA = std::make_shared<Node>("A5");

--- a/tests/NodeTest.cpp
+++ b/tests/NodeTest.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include "../includes/Node.hpp"
+#include "../includes/Edge.hpp" // Include the Edge header
 #include "../includes/colours.hpp"	// Include the colours header
 
 bool testAddEdges()

--- a/tests/RailNetworkTest.cpp
+++ b/tests/RailNetworkTest.cpp
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   RailNetwork.cpp                                    :+:      :+:    :+:   */
+/*   RailNetworkTest.cpp                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: andrefrancisco <andrefrancisco@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
@@ -10,6 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "Edge.hpp"
 #include "../includes/RailNetwork.hpp"
 
 // Add a node to the rail network

--- a/tests/RailNetworkTest.cpp
+++ b/tests/RailNetworkTest.cpp
@@ -6,12 +6,12 @@
 /*   By: andrefrancisco <andrefrancisco@student.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/15 14:22:37 by andrefranci       #+#    #+#             */
-/*   Updated: 2025/03/08 11:51:51 by andrefranci      ###   ########.fr       */
+/*   Updated: 2025/05/18 16:18:10 by andrefranci      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "Edge.hpp"
 #include "../includes/RailNetwork.hpp"
+#include "Edge.hpp"
 
 // Add a node to the rail network
 void RailNetwork::addNode(std::shared_ptr<Node> node)
@@ -22,10 +22,10 @@ void RailNetwork::addNode(std::shared_ptr<Node> node)
 	}
 }
 
-// Add a connection (edge) between two nodes with a specific distance and speed limit
+// Add a connection (edge) between two nodes with a specific distance and speed
+// limit
 void RailNetwork::addConnection(std::shared_ptr<Node> node1,
-								std::shared_ptr<Node> node2,
-								size_t distance,
+								std::shared_ptr<Node> node2, size_t distance,
 								size_t speedLimit)
 {
 	if (node1 == node2)
@@ -58,8 +58,8 @@ void RailNetwork::addConnection(std::shared_ptr<Node> node1,
 }
 
 // Get the neighbors of a node
-const std::vector<Edge>
-	&RailNetwork::getNeighbours(std::shared_ptr<Node> node) const
+const std::vector<Edge> &RailNetwork::getNeighbours(
+	std::shared_ptr<Node> node) const
 {
 	auto it = _adjacencyList.find(node);
 	if (it != _adjacencyList.end())

--- a/tests/test_RailNetwork.cpp
+++ b/tests/test_RailNetwork.cpp
@@ -4,10 +4,10 @@
 
 #include <iostream>
 
+#include "../includes/Edge.hpp"
 #include "../includes/Node.hpp"
 #include "../includes/RailNetwork.hpp"
 #include "../includes/colours.hpp"
-#include "../includes/Edge.hpp"
 
 static void printTestSuiteHeader()
 {
@@ -63,12 +63,13 @@ static bool testAddConnection()
 	auto &network = RailNetwork::getInstance();
 	auto  nodeA = std::make_shared<Node>("NodeA");
 	auto  nodeB = std::make_shared<Node>("NodeB");
-	network.addConnection(nodeA, nodeB, 5, 100); // Add speedLimit argument
+	network.addConnection(nodeA, nodeB, 5, 100);  // Add speedLimit argument
 
 	bool connectionExists = false;
 	for (auto &neighbor : network.getNeighbours(nodeA))
 	{
-		if (neighbor.node.lock()->getName() == "NodeB" && neighbor.distance == 5)
+		if (neighbor.node.lock()->getName() == "NodeB"
+			&& neighbor.distance == 5)
 		{
 			connectionExists = true;
 			break;
@@ -98,7 +99,7 @@ static bool testGetNeighbours()
 	auto &network = RailNetwork::getInstance();
 	auto  nodeA = std::make_shared<Node>("NodeC");
 	auto  nodeB = std::make_shared<Node>("NodeD");
-	network.addConnection(nodeA, nodeB, 7, 80); // Add speedLimit argument
+	network.addConnection(nodeA, nodeB, 7, 80);	 // Add speedLimit argument
 
 	auto neighbours = network.getNeighbours(nodeA);
 	bool foundB = false;
@@ -125,8 +126,8 @@ static bool testPrintNetwork()
 	network.addNode(nodeX);
 	network.addNode(nodeY);
 	network.addNode(nodeZ);
-	network.addConnection(nodeX, nodeY, 10, 100); // Add speedLimit argument
-	network.addConnection(nodeX, nodeZ, 15, 100); // Add speedLimit argument
+	network.addConnection(nodeX, nodeY, 10, 100);  // Add speedLimit argument
+	network.addConnection(nodeX, nodeZ, 15, 100);  // Add speedLimit argument
 	std::cout << "Testing printNetwork() (no validation, just ensure no crash):"
 			  << std::endl;
 	network.printNetwork();
@@ -143,7 +144,7 @@ static bool testDuplicateNode()
 	{
 		network.addNode(std::make_shared<Node>("DuplicateNode"));
 	}
-	catch (const Node::DuplicateNodeException &)
+	catch (const Node::InvalidNodeException &)
 	{
 		exceptionThrown = true;
 	}
@@ -160,7 +161,7 @@ static bool testSelfEdge()
 	bool exceptionThrown = false;
 	try
 	{
-		network.addConnection(node, node, 5, 100); // Add speedLimit argument
+		network.addConnection(node, node, 5, 100);	// Add speedLimit argument
 	}
 	catch (const Node::SelfEdgeException &)
 	{
@@ -176,11 +177,11 @@ static bool testEdgeAlreadyExists()
 	auto &network = RailNetwork::getInstance();
 	auto  nodeA = std::make_shared<Node>("NodeA");
 	auto  nodeB = std::make_shared<Node>("NodeB");
-	network.addConnection(nodeA, nodeB, 5, 100); // Add speedLimit argument
+	network.addConnection(nodeA, nodeB, 5, 100);  // Add speedLimit argument
 	bool exceptionThrown = false;
 	try
 	{
-		network.addConnection(nodeA, nodeB, 5, 100); // Add speedLimit argument
+		network.addConnection(nodeA, nodeB, 5, 100);  // Add speedLimit argument
 	}
 	catch (const RailNetwork::ConnectionAlreadyExistsException &)
 	{
@@ -216,6 +217,111 @@ static bool testEmptyNetwork()
 	bool  isEmpty = nodes.empty();
 	return printResult("EmptyNetwork", isEmpty, "No nodes in network",
 					   isEmpty ? "No nodes" : "Nodes present");
+}
+
+static bool testAddSameConnectionTwice()
+{
+	std::cout << BLUE << "[TEST] AddSameConnectionTwice" << RESET << std::endl;
+	auto &network = RailNetwork::getInstance();
+	auto  nodeA = std::make_shared<Node>("SameConnA");
+	auto  nodeB = std::make_shared<Node>("SameConnB");
+	network.addConnection(nodeA, nodeB, 12, 90);
+	bool exceptionThrown = false;
+	try
+	{
+		network.addConnection(nodeA, nodeB, 12, 90);
+	}
+	catch (const RailNetwork::ConnectionAlreadyExistsException &)
+	{
+		exceptionThrown = true;
+	}
+	return printResult("AddSameConnectionTwice", exceptionThrown,
+					   "Exception thrown",
+					   exceptionThrown ? "Exception thrown" : "No exception");
+}
+
+static bool testAddConnectionWithNegativeDistance()
+{
+	std::cout << BLUE << "[TEST] AddConnectionWithNegativeDistance" << RESET
+			  << std::endl;
+	auto &network = RailNetwork::getInstance();
+	auto  nodeA = std::make_shared<Node>("NegDistA");
+	auto  nodeB = std::make_shared<Node>("NegDistB");
+	network.addNode(nodeA);
+	network.addNode(nodeB);
+	bool exceptionThrown = false;
+	try
+	{
+		network.addConnection(nodeA, nodeB, -5, 100);
+	}
+	catch (const Node::InvalidEdgeException &)
+	{
+		exceptionThrown = true;
+	}
+	catch (const std::invalid_argument &)
+	{
+		exceptionThrown = true;
+	}
+	if (!exceptionThrown)
+	{
+		std::cout
+			<< YELLOW
+			<< "[DEBUG] Printing network after negative distance connection:"
+			<< RESET << std::endl;
+		network.printNetwork();
+	}
+	return printResult("AddConnectionWithNegativeDistance", exceptionThrown,
+					   "Exception thrown",
+					   exceptionThrown ? "Exception thrown" : "No exception");
+}
+
+static bool testAddConnectionWithNegativeSpeed()
+{
+	std::cout << BLUE << "[TEST] AddConnectionWithNegativeSpeed" << RESET
+			  << std::endl;
+	auto &network = RailNetwork::getInstance();
+	auto  nodeA = std::make_shared<Node>("NegSpeedA");
+	auto  nodeB = std::make_shared<Node>("NegSpeedB");
+	network.addNode(nodeA);
+	network.addNode(nodeB);
+	bool exceptionThrown = false;
+	try
+	{
+		network.addConnection(nodeA, nodeB, 10, -50);
+	}
+	catch (const Node::InvalidEdgeException &)
+	{
+		exceptionThrown = true;
+	}
+	catch (const std::invalid_argument &)
+	{
+		exceptionThrown = true;
+	}
+	return printResult("AddConnectionWithNegativeSpeed", exceptionThrown,
+					   "Exception thrown",
+					   exceptionThrown ? "Exception thrown" : "No exception");
+}
+
+static bool testAddNodeWithEmptyName()
+{
+	std::cout << BLUE << "[TEST] AddNodeWithEmptyName" << RESET << std::endl;
+	auto &network = RailNetwork::getInstance();
+	bool  exceptionThrown = false;
+	try
+	{
+		network.addNode(std::make_shared<Node>(""));
+	}
+	catch (const Node::InvalidNodeException &)
+	{
+		exceptionThrown = true;
+	}
+	catch (const std::invalid_argument &)
+	{
+		exceptionThrown = true;
+	}
+	return printResult("AddNodeWithEmptyName", exceptionThrown,
+					   "Exception thrown",
+					   exceptionThrown ? "Exception thrown" : "No exception");
 }
 
 /*  Helper function to run a test function in a child process
@@ -260,6 +366,10 @@ int main(void)
 	allTestsPassed &= runTest(testEdgeAlreadyExists);
 	allTestsPassed &= runTest(testNonExistentNode);
 	allTestsPassed &= runTest(testEmptyNetwork);
+	allTestsPassed &= runTest(testAddSameConnectionTwice);
+	allTestsPassed &= runTest(testAddConnectionWithNegativeDistance);
+	allTestsPassed &= runTest(testAddConnectionWithNegativeSpeed);
+	allTestsPassed &= runTest(testAddNodeWithEmptyName);
 	std::cout << (allTestsPassed ? GREEN : RED) << "All tests completed."
 			  << RESET << std::endl;
 	return allTestsPassed ? 0 : 1;

--- a/tests/test_RailNetwork.cpp
+++ b/tests/test_RailNetwork.cpp
@@ -7,6 +7,7 @@
 #include "../includes/Node.hpp"
 #include "../includes/RailNetwork.hpp"
 #include "../includes/colours.hpp"
+#include "../includes/Edge.hpp"
 
 static void printTestSuiteHeader()
 {
@@ -62,12 +63,12 @@ static bool testAddConnection()
 	auto &network = RailNetwork::getInstance();
 	auto  nodeA = std::make_shared<Node>("NodeA");
 	auto  nodeB = std::make_shared<Node>("NodeB");
-	network.addConnection(nodeA, nodeB, 5);
+	network.addConnection(nodeA, nodeB, 5, 100); // Add speedLimit argument
 
 	bool connectionExists = false;
 	for (auto &neighbor : network.getNeighbours(nodeA))
 	{
-		if (neighbor.first->getName() == "NodeB" && neighbor.second == 5)
+		if (neighbor.node.lock()->getName() == "NodeB" && neighbor.distance == 5)
 		{
 			connectionExists = true;
 			break;
@@ -97,13 +98,13 @@ static bool testGetNeighbours()
 	auto &network = RailNetwork::getInstance();
 	auto  nodeA = std::make_shared<Node>("NodeC");
 	auto  nodeB = std::make_shared<Node>("NodeD");
-	network.addConnection(nodeA, nodeB, 7);
+	network.addConnection(nodeA, nodeB, 7, 80); // Add speedLimit argument
 
 	auto neighbours = network.getNeighbours(nodeA);
 	bool foundB = false;
 	for (auto &n : neighbours)
 	{
-		if (n.first->getName() == "NodeD" && n.second == 7)
+		if (n.node.lock()->getName() == "NodeD" && n.distance == 7)
 		{
 			foundB = true;
 			break;
@@ -124,8 +125,8 @@ static bool testPrintNetwork()
 	network.addNode(nodeX);
 	network.addNode(nodeY);
 	network.addNode(nodeZ);
-	network.addConnection(nodeX, nodeY, 10);
-	network.addConnection(nodeX, nodeZ, 15);
+	network.addConnection(nodeX, nodeY, 10, 100); // Add speedLimit argument
+	network.addConnection(nodeX, nodeZ, 15, 100); // Add speedLimit argument
 	std::cout << "Testing printNetwork() (no validation, just ensure no crash):"
 			  << std::endl;
 	network.printNetwork();
@@ -159,7 +160,7 @@ static bool testSelfEdge()
 	bool exceptionThrown = false;
 	try
 	{
-		network.addConnection(node, node, 5);
+		network.addConnection(node, node, 5, 100); // Add speedLimit argument
 	}
 	catch (const Node::SelfEdgeException &)
 	{
@@ -175,11 +176,11 @@ static bool testEdgeAlreadyExists()
 	auto &network = RailNetwork::getInstance();
 	auto  nodeA = std::make_shared<Node>("NodeA");
 	auto  nodeB = std::make_shared<Node>("NodeB");
-	network.addConnection(nodeA, nodeB, 5);
+	network.addConnection(nodeA, nodeB, 5, 100); // Add speedLimit argument
 	bool exceptionThrown = false;
 	try
 	{
-		network.addConnection(nodeA, nodeB, 5);
+		network.addConnection(nodeA, nodeB, 5, 100); // Add speedLimit argument
 	}
 	catch (const RailNetwork::ConnectionAlreadyExistsException &)
 	{


### PR DESCRIPTION
- Move Edge struct to a dedicated Edge.hpp header for reuse and clarity.
- Update Node and RailNetwork to use the new Edge struct instead of local definitions.
- Change RailNetwork's adjacency list to use std::vector<Edge> for each node.
- Update addConnection and getNeighbours signatures to use Edge and include speedLimit.
- Update all usages and tests to match the new Edge-based API.
- Ensure Node's internal edge list stays in sync with RailNetwork.
- Add Edge.hpp includes where necessary.