### PR TITLE
feat: expand test coverage and harden error handling\n\nError handling improvements.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/EventTest
         valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/DijkstraTest
         valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/InputHandlerTest
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/TrainFactoryTest
+        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/OutputManagerTest
 
     - name: Valgrind - main program
       run: |

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ TESTS = $(BINDIR)/NodeTest \
 		$(BINDIR)/TrainTest \
 		$(BINDIR)/EventTest \
 		$(BINDIR)/DijkstraTest \
-		$(BINDIR)/InputHandlerTest
+		$(BINDIR)/InputHandlerTest \
+		$(BINDIR)/TrainFactoryTest \
+		$(BINDIR)/OutputManagerTest
 
 test: $(TESTS)
 	@echo ""
@@ -80,6 +82,8 @@ test: $(TESTS)
 	@./$(BINDIR)/EventTest || exit 1
 	@./$(BINDIR)/DijkstraTest || exit 1
 	@./$(BINDIR)/InputHandlerTest || exit 1
+	@./$(BINDIR)/TrainFactoryTest || exit 1
+	@./$(BINDIR)/OutputManagerTest || exit 1
 
 $(BINDIR)/NodeTest: $(TESTDIR)/NodeTest.cpp $(OBJDIR)/Node/Node.o
 	@mkdir -p $(BINDIR)
@@ -110,6 +114,19 @@ $(BINDIR)/InputHandlerTest: $(TESTDIR)/InputHandlerTest.cpp \
 	$(OBJDIR)/RailNetwork/RailNetwork.o $(OBJDIR)/Node/Node.o \
 	$(OBJDIR)/Event/Event.o $(OBJDIR)/Train/Train.o \
 	$(OBJDIR)/TrainFactory/TrainFactory.o
+	@mkdir -p $(BINDIR)
+	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+
+$(BINDIR)/TrainFactoryTest: $(TESTDIR)/TrainFactoryTest.cpp \
+	$(OBJDIR)/TrainFactory/TrainFactory.o $(OBJDIR)/Train/Train.o \
+	$(OBJDIR)/Node/Node.o
+	@mkdir -p $(BINDIR)
+	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+
+$(BINDIR)/OutputManagerTest: $(TESTDIR)/OutputManagerTest.cpp \
+	$(OBJDIR)/OutputManager/OutputManager.o \
+	$(OBJDIR)/Train/Train.o $(OBJDIR)/Node/Node.o \
+	$(OBJDIR)/Event/Event.o $(OBJDIR)/RailNetwork/RailNetwork.o
 	@mkdir -p $(BINDIR)
 	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 

--- a/src/DijkstraPathfinding/DijkstraPathfinding.cpp
+++ b/src/DijkstraPathfinding/DijkstraPathfinding.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   DijkstraPathfinding.cpp                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,13 @@ std::vector<std::shared_ptr<Node>> DijkstraPathfinding::findPath(
 	const std::string &start, const std::string &end,
 	const RailNetwork &network) const
 {
+	// Validate that both nodes exist in the network
+	network.findNode(start);
+	network.findNode(end);
+
+	if (start == end)
+		return {network.findNode(start)};
+
 	using Pair = std::pair<double, std::string>;
 	std::priority_queue<Pair, std::vector<Pair>, std::greater<Pair>> pq;
 

--- a/src/Event/Event.cpp
+++ b/src/Event/Event.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Event.cpp                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,14 @@ Event::Event(const std::string &name, double probability, double duration,
 	: _name(name), _probability(probability), _duration(duration),
 	  _nodeName(nodeName)
 {
+	if (name.empty())
+		throw std::invalid_argument("Event name cannot be empty");
+	if (probability < 0.0 || probability > 1.0)
+		throw std::invalid_argument("Probability must be in [0, 1]");
+	if (duration < 0.0)
+		throw std::invalid_argument("Duration cannot be negative");
+	if (nodeName.empty())
+		throw std::invalid_argument("Node name cannot be empty");
 }
 
 Event::Event(const Event &src)

--- a/src/Event/Event.hpp
+++ b/src/Event/Event.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Event.hpp                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #define EVENT_HPP
 
 #include <random>
+#include <stdexcept>
 #include <string>
 
 class Event

--- a/src/InputHandler/InputHandler.cpp
+++ b/src/InputHandler/InputHandler.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   InputHandler.cpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,19 @@ static double parseDuration(const std::string &str)
 	if (str.empty())
 		throw InputHandler::ParseException("Empty duration string");
 	char unit = str.back();
-	double value = std::stod(str.substr(0, str.size() - 1));
+	double value;
+	try
+	{
+		value = std::stod(str.substr(0, str.size() - 1));
+	}
+	catch (const std::exception &)
+	{
+		throw InputHandler::ParseException(
+			"Invalid duration value: " + str);
+	}
+	if (value < 0.0)
+		throw InputHandler::ParseException(
+			"Duration cannot be negative: " + str);
 	switch (unit)
 	{
 		case 'm':
@@ -64,10 +76,21 @@ static double parseTime(const std::string &str)
 	size_t hPos = str.find('h');
 	if (hPos == std::string::npos)
 		throw InputHandler::ParseException("Invalid time format: " + str);
-	int hours = std::stoi(str.substr(0, hPos));
-	int minutes = 0;
-	if (hPos + 1 < str.size())
-		minutes = std::stoi(str.substr(hPos + 1));
+	int hours, minutes = 0;
+	try
+	{
+		hours = std::stoi(str.substr(0, hPos));
+		if (hPos + 1 < str.size())
+			minutes = std::stoi(str.substr(hPos + 1));
+	}
+	catch (const std::exception &)
+	{
+		throw InputHandler::ParseException(
+			"Invalid time value: " + str);
+	}
+	if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59)
+		throw InputHandler::ParseException(
+			"Time out of range: " + str);
 	return hours * 3600.0 + minutes * 60.0;
 }
 
@@ -123,7 +146,7 @@ void InputHandler::parseNetworkFile(const std::string &filepath,
 			std::string from, to;
 			double distance, speedLimit;
 			iss >> from >> to >> distance >> speedLimit;
-			if (from.empty() || to.empty())
+			if (iss.fail() || from.empty() || to.empty())
 				throw ParseException("Invalid rail line: " + line);
 			network.addConnection(from, to, distance, speedLimit);
 		}
@@ -153,8 +176,8 @@ std::vector<std::unique_ptr<Train>> InputHandler::parseTrainFile(
 		double accel, brake;
 		std::string departure, arrival, timeStr;
 		iss >> name >> accel >> brake >> departure >> arrival >> timeStr;
-		if (name.empty() || departure.empty() || arrival.empty()
-			|| timeStr.empty())
+		if (iss.fail() || name.empty() || departure.empty()
+			|| arrival.empty() || timeStr.empty())
 			throw ParseException("Invalid train line: " + line);
 		trains.push_back(TrainFactory::createTrain(
 			name, accel, brake, departure, arrival, parseTime(timeStr)));

--- a/src/Simulation/Simulation.cpp
+++ b/src/Simulation/Simulation.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Simulation.cpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,8 @@ Simulation::Simulation(RailNetwork network,
 	  _events(std::move(events)), _pathfinder(std::move(pathfinder)),
 	  _rng(std::random_device{}())
 {
+	if (!_pathfinder)
+		throw std::invalid_argument("Pathfinder cannot be null");
 }
 
 Simulation::~Simulation() {}
@@ -109,7 +111,7 @@ double Simulation::getEdgeTravelTime(const std::string &from,
 		if (edge.destination->getName() == to)
 			return (edge.distance / edge.speedLimit) * 3600.0;
 	}
-	return 0.0;
+	throw std::runtime_error("No edge from " + from + " to " + to);
 }
 
 std::vector<const Event *> Simulation::getEventsAtNode(

--- a/src/Train/Train.cpp
+++ b/src/Train/Train.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Train.cpp                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,6 +67,8 @@ void Train::setPath(const std::vector<std::shared_ptr<Node>> &path)
 
 void Train::advanceToNextNode(double travelTime)
 {
+	if (_path.size() < 2)
+		return;
 	_currentTime += travelTime;
 	_pathIndex++;
 	if (_pathIndex >= _path.size() - 1)

--- a/src/TrainFactory/TrainFactory.cpp
+++ b/src/TrainFactory/TrainFactory.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   TrainFactory.cpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,8 @@ std::unique_ptr<Train> TrainFactory::createTrain(
 		throw std::invalid_argument("Station names cannot be empty");
 	if (departure == arrival)
 		throw std::invalid_argument("Departure and arrival must differ");
+	if (departureTime < 0.0)
+		throw std::invalid_argument("Departure time cannot be negative");
 	return std::make_unique<Train>(name, acceleration, braking, departure,
 								   arrival, departureTime);
 }

--- a/tests/DijkstraTest.cpp
+++ b/tests/DijkstraTest.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   DijkstraTest.cpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,26 @@ int main()
 		ASSERT_STR_EQ(std::string("A"), path[0]->getName(), msg);
 		return true;
 	});
+
+	suite.run("throws when start node not in network",
+			  [](std::string &msg) {
+				  RailNetwork net;
+				  net.addNode("B");
+				  DijkstraPathfinding dijk;
+				  ASSERT_THROWS(dijk.findPath("Ghost", "B", net),
+								RailNetwork::NodeNotFoundException, msg);
+				  return true;
+			  });
+
+	suite.run("throws when end node not in network",
+			  [](std::string &msg) {
+				  RailNetwork net;
+				  net.addNode("A");
+				  DijkstraPathfinding dijk;
+				  ASSERT_THROWS(dijk.findPath("A", "Ghost", net),
+								RailNetwork::NodeNotFoundException, msg);
+				  return true;
+			  });
 
 	return suite.summarize();
 }

--- a/tests/EventTest.cpp
+++ b/tests/EventTest.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   EventTest.cpp                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,6 +69,36 @@ int main()
 				  ASSERT_TRUE(ratio > 0.45 && ratio < 0.55, msg);
 				  return true;
 			  });
+
+	suite.run("throws on empty name", [](std::string &msg) {
+		ASSERT_THROWS(Event("", 0.5, 100.0, "N"),
+					  std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on negative probability", [](std::string &msg) {
+		ASSERT_THROWS(Event("Bad", -0.1, 100.0, "N"),
+					  std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on probability > 1", [](std::string &msg) {
+		ASSERT_THROWS(Event("Bad", 1.1, 100.0, "N"),
+					  std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on negative duration", [](std::string &msg) {
+		ASSERT_THROWS(Event("Bad", 0.5, -1.0, "N"),
+					  std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on empty node name", [](std::string &msg) {
+		ASSERT_THROWS(Event("Bad", 0.5, 100.0, ""),
+					  std::invalid_argument, msg);
+		return true;
+	});
 
 	return suite.summarize();
 }

--- a/tests/InputHandlerTest.cpp
+++ b/tests/InputHandlerTest.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   InputHandlerTest.cpp                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,27 @@ int main()
 			InputHandler::ParseException, msg);
 		return true;
 	});
+
+	suite.run("throws on missing rail file only",
+			  [](std::string &msg) {
+				  ASSERT_THROWS(
+					  InputHandler::loadData(
+						  "nonexistent.txt",
+						  "input/trainPrintFolder/trainPrintGood.txt"),
+					  InputHandler::ParseException, msg);
+				  return true;
+			  });
+
+	suite.run("throws on missing train file only",
+			  [](std::string &msg) {
+				  ASSERT_THROWS(
+					  InputHandler::loadData(
+						  "input/railNetworkPrintFolder/"
+						  "railNetworkPrintGood.txt",
+						  "missing_trains.txt"),
+					  InputHandler::ParseException, msg);
+				  return true;
+			  });
 
 	return suite.summarize();
 }

--- a/tests/NodeTest.cpp
+++ b/tests/NodeTest.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   NodeTest.cpp                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:23:11 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,14 @@ int main()
 		Node b("AssignB");
 		b = a;
 		ASSERT_STR_EQ(std::string("AssignA"), b.getName(), msg);
+		return true;
+	});
+
+	suite.run("self-assignment is safe", [](std::string &msg) {
+		Node a("SelfTest");
+		Node &ref = a;
+		a = ref;
+		ASSERT_STR_EQ(std::string("SelfTest"), a.getName(), msg);
 		return true;
 	});
 

--- a/tests/OutputManagerTest.cpp
+++ b/tests/OutputManagerTest.cpp
@@ -1,0 +1,52 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   OutputManagerTest.cpp                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
+/*   Updated: 2026/02/21 03:24:01 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "OutputManager.hpp"
+#include "TestFramework.hpp"
+
+int main()
+{
+	Test::TestSuite suite("OutputManager");
+
+	suite.run("formatTime midnight", [](std::string &msg) {
+		ASSERT_STR_EQ(std::string("00:00:00"),
+					  OutputManager::formatTime(0.0), msg);
+		return true;
+	});
+
+	suite.run("formatTime one hour one minute one second",
+			  [](std::string &msg) {
+				  ASSERT_STR_EQ(std::string("01:01:01"),
+								OutputManager::formatTime(3661.0), msg);
+				  return true;
+			  });
+
+	suite.run("formatTime end of day", [](std::string &msg) {
+		ASSERT_STR_EQ(std::string("23:59:59"),
+					  OutputManager::formatTime(86399.0), msg);
+		return true;
+	});
+
+	suite.run("formatTime wraps at 24h", [](std::string &msg) {
+		ASSERT_STR_EQ(std::string("00:00:00"),
+					  OutputManager::formatTime(86400.0), msg);
+		return true;
+	});
+
+	suite.run("formatTime 14h10", [](std::string &msg) {
+		ASSERT_STR_EQ(std::string("14:10:00"),
+					  OutputManager::formatTime(51000.0), msg);
+		return true;
+	});
+
+	return suite.summarize();
+}

--- a/tests/RailNetworkTest.cpp
+++ b/tests/RailNetworkTest.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   RailNetworkTest.cpp                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,6 +122,37 @@ int main()
 				  ASSERT_STR_EQ(std::string("Alpha"), names[0], msg);
 				  ASSERT_STR_EQ(std::string("Bravo"), names[1], msg);
 				  ASSERT_STR_EQ(std::string("Charlie"), names[2], msg);
+				  return true;
+			  });
+
+	suite.run("getNeighbours throws on unknown node",
+			  [](std::string &msg) {
+				  RailNetwork net;
+				  ASSERT_THROWS(net.getNeighbours("Ghost"),
+								RailNetwork::NodeNotFoundException, msg);
+				  return true;
+			  });
+
+	suite.run("addConnection throws on zero speed limit",
+			  [](std::string &msg) {
+				  RailNetwork net;
+				  net.addNode("A");
+				  net.addNode("B");
+				  ASSERT_THROWS(
+					  net.addConnection("A", "B", 10.0, 0.0),
+					  std::invalid_argument, msg);
+				  return true;
+			  });
+
+	suite.run("copy constructor copies data",
+			  [](std::string &msg) {
+				  RailNetwork net;
+				  net.addNode("X");
+				  net.addNode("Y");
+				  net.addConnection("X", "Y", 5.0, 50.0);
+				  RailNetwork copy(net);
+				  ASSERT_EQ(2u, copy.nodeCount(), msg);
+				  ASSERT_EQ(1u, copy.getNeighbours("X").size(), msg);
 				  return true;
 			  });
 

--- a/tests/TrainFactoryTest.cpp
+++ b/tests/TrainFactoryTest.cpp
@@ -1,0 +1,84 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   TrainFactoryTest.cpp                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
+/*   Updated: 2026/02/21 03:24:01 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "TestFramework.hpp"
+#include "TrainFactory.hpp"
+
+int main()
+{
+	Test::TestSuite suite("TrainFactory");
+
+	suite.run("creates valid train", [](std::string &msg) {
+		auto t = TrainFactory::createTrain("Express", 1.5, 1.2, "A", "B",
+										   3600.0);
+		ASSERT_TRUE(t != nullptr, msg);
+		ASSERT_STR_EQ(std::string("Express"), t->getName(), msg);
+		ASSERT_TRUE(t->getMaxAcceleration() == 1.5, msg);
+		ASSERT_TRUE(t->getMaxBrakingForce() == 1.2, msg);
+		return true;
+	});
+
+	suite.run("throws on empty name", [](std::string &msg) {
+		ASSERT_THROWS(
+			TrainFactory::createTrain("", 1.0, 1.0, "A", "B", 0.0),
+			std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on zero acceleration", [](std::string &msg) {
+		ASSERT_THROWS(
+			TrainFactory::createTrain("T", 0.0, 1.0, "A", "B", 0.0),
+			std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on negative acceleration", [](std::string &msg) {
+		ASSERT_THROWS(
+			TrainFactory::createTrain("T", -1.0, 1.0, "A", "B", 0.0),
+			std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on zero braking", [](std::string &msg) {
+		ASSERT_THROWS(
+			TrainFactory::createTrain("T", 1.0, 0.0, "A", "B", 0.0),
+			std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on empty departure", [](std::string &msg) {
+		ASSERT_THROWS(
+			TrainFactory::createTrain("T", 1.0, 1.0, "", "B", 0.0),
+			std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on same departure and arrival",
+			  [](std::string &msg) {
+				  ASSERT_THROWS(
+					  TrainFactory::createTrain("T", 1.0, 1.0, "A", "A",
+												0.0),
+					  std::invalid_argument, msg);
+				  return true;
+			  });
+
+	suite.run("throws on negative departure time",
+			  [](std::string &msg) {
+				  ASSERT_THROWS(
+					  TrainFactory::createTrain("T", 1.0, 1.0, "A", "B",
+												-100.0),
+					  std::invalid_argument, msg);
+				  return true;
+			  });
+
+	return suite.summarize();
+}

--- a/tests/TrainTest.cpp
+++ b/tests/TrainTest.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   TrainTest.cpp                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,39 @@ int main()
 				  ASSERT_STR_EQ(std::string("Arrived"),
 								Train::statusToString(TrainStatus::Arrived),
 								msg);
+				  return true;
+			  });
+
+	suite.run("statusToString for Running and Delayed",
+			  [](std::string &msg) {
+				  ASSERT_STR_EQ(std::string("Running"),
+								Train::statusToString(TrainStatus::Running),
+								msg);
+				  ASSERT_STR_EQ(std::string("Delayed"),
+								Train::statusToString(TrainStatus::Delayed),
+								msg);
+				  return true;
+			  });
+
+	suite.run("getCurrentNodeName empty path returns empty",
+			  [](std::string &msg) {
+				  Train t("T", 1.0, 1.0, "A", "B", 0.0);
+				  ASSERT_STR_EQ(std::string(""), t.getCurrentNodeName(), msg);
+				  return true;
+			  });
+
+	suite.run("advanceToNextNode on empty path is safe",
+			  [](std::string &msg) {
+				  Train t("T", 1.0, 1.0, "A", "B", 0.0);
+				  t.advanceToNextNode(100.0);
+				  ASSERT_EQ(0u, t.getPathIndex(), msg);
+				  return true;
+			  });
+
+	suite.run("hasArrived is false after construction",
+			  [](std::string &msg) {
+				  Train t("T", 1.0, 1.0, "A", "B", 0.0);
+				  ASSERT_FALSE(t.hasArrived(), msg);
 				  return true;
 			  });
 


### PR DESCRIPTION
- DijkstraPathfinding: validate start/end nodes exist before pathfinding
- Train: guard advanceToNextNode against empty/single-node path
- Simulation: throw on missing edge instead of silent 0.0; null pathfinder check
-  InputHandler: wrap stod/stoi in try-catch, validate time ranges and stream state\n- Event: validate name, probability [0,1], duration >= 0, nodeName in constructor\n- TrainFactory: reject negative departure time\n\nNew test suites:
- TrainFactoryTest (8 tests): valid creation, empty name, zero/negative accel,  zero braking, empty departure, same departure/arrival, negative departure time
- OutputManagerTest (5 tests): formatTime for midnight, 01:01:01, end of day, 24h wrap, 14h10. Expanded existing suites: NodeTest: +1 (self-assignment safety) 
- EventTest: +5 (empty name, negative/over-1 probability, negative duration, empty node name) 
- TrainTest: +4 (Running/Delayed statusToString, getCurrentNodeName on empty path, advanceToNextNode on empty path, hasArrived after construction) - DijkstraTest: +2 (start/end node not in network throws)
- RailNetworkTest: +3 (getNeighbours unknown node, zero speed limit, copy ctor) 
- InputHandlerTest: +2 (missing rail file only, missing train file only) Total: 68 tests across 8 suites (was 38 across 6)."}

</invoke>

## Description

<!-- What does this PR do? Why is it needed? -->

## Screenshots

<!-- Add screenshots or terminal output if applicable. Remove this section if not relevant. -->

## How to Test

```bash
make fclean && make all    # build
make run                   # run with sample input
make test                  # run all test suites
```

<!-- Add any additional testing steps specific to this PR -->

## Checklist

- [ ] Compiles with `make CXX=g++` and `make CXX=clang++` (zero warnings)
- [ ] All tests pass (`make test`)
- [ ] No memory leaks (valgrind clean)

