### PR TITLE
feat: full spec compliance — physics sim, observer pattern, per-train .result output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ objs/
 *.dSYM/
 .nfs*
 
+# Simulation result files
+*.result
+
 # macOS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ INC			= -I$(SRCDIR)/Edge \
 			  -I$(SRCDIR)/DijkstraPathfinding \
 			  -I$(SRCDIR)/InputHandler \
 			  -I$(SRCDIR)/OutputManager \
-			  -I$(SRCDIR)/Simulation
+			  -I$(SRCDIR)/Simulation \
+			  -I$(SRCDIR)/ISimulationObserver \
+			  -I$(SRCDIR)/FileOutputObserver
 
 # Source files
 SRCS		= $(SRCDIR)/main.cpp \
@@ -33,7 +35,8 @@ SRCS		= $(SRCDIR)/main.cpp \
 			  $(SRCDIR)/DijkstraPathfinding/DijkstraPathfinding.cpp \
 			  $(SRCDIR)/InputHandler/InputHandler.cpp \
 			  $(SRCDIR)/OutputManager/OutputManager.cpp \
-			  $(SRCDIR)/Simulation/Simulation.cpp
+			  $(SRCDIR)/Simulation/Simulation.cpp \
+			  $(SRCDIR)/FileOutputObserver/FileOutputObserver.cpp
 
 # Object files
 OBJS		= $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))

--- a/input/trainPrintFolder/trainPrintGood.txt
+++ b/input/trainPrintFolder/trainPrintGood.txt
@@ -1,3 +1,3 @@
-TrainAB1 1.87 1.4 CityA CityB 14h10
-TrainAC 1.94 1.3 CityA CityC 14h20
-TrainAB2 1.87 1.4 CityA CityB 14h24
+TrainAB 80 0.05 356.0 30.0 CityA CityB 14h10 00h10
+TrainAC 60 0.05 412.0 40.0 CityA CityC 14h20 00h10
+TrainBA 40 0.05 356.0 30.0 CityA CityB 14h24 00h10

--- a/src/FileOutputObserver/FileOutputObserver.cpp
+++ b/src/FileOutputObserver/FileOutputObserver.cpp
@@ -1,0 +1,141 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   FileOutputObserver.cpp                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "FileOutputObserver.hpp"
+
+#include <cstdio>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+/* ---- Static helpers ---- */
+std::string FileOutputObserver::fmtTimeShort(double seconds)
+{
+	int total = static_cast<int>(seconds);
+	int h = total / 3600;
+	int m = (total % 3600) / 60;
+	char buf[16];
+	std::snprintf(buf, sizeof(buf), "%02dh%02d", h, m);
+	return buf;
+}
+
+std::string FileOutputObserver::buildFilename(const std::string &trainName,
+											  double departureTimeSec)
+{
+	return trainName + "_" + fmtTimeShort(departureTimeSec) + ".result";
+}
+
+std::string FileOutputObserver::padRight(const std::string &s,
+										 size_t width)
+{
+	if (s.size() >= width)
+		return s;
+	return std::string(width - s.size(), ' ') + s;
+}
+
+/* ---- Constructor / Destructor ---- */
+FileOutputObserver::FileOutputObserver(const std::string &trainName,
+									   double departureTimeSec)
+	: _filename(buildFilename(trainName, departureTimeSec))
+{
+	_file.open(_filename);
+	if (!_file.is_open())
+		throw std::runtime_error("Cannot create output file: " + _filename);
+}
+
+FileOutputObserver::~FileOutputObserver()
+{
+	if (_file.is_open())
+		_file.close();
+}
+
+/* ---- Observer callbacks ---- */
+void FileOutputObserver::onTrainStart(const std::string &trainName,
+									  double estimatedTimeSec)
+{
+	_file << "Train : " << trainName << "\n";
+	_file << "Final travel time : " << fmtTimeShort(estimatedTimeSec)
+		  << "m\n\n";
+}
+
+void FileOutputObserver::onTrainStep(double timeSinceStart,
+									 const std::string &fromNode,
+									 const std::string &toNode,
+									 double distRemainingKm,
+									 const std::string &action,
+									 int positionCellKm,
+									 int segmentCellsKm,
+									 const std::vector<int> &blockingCells)
+{
+	// Time
+	_file << "[" << fmtTimeShort(timeSinceStart) << "] - ";
+
+	// Segment nodes (right-padded to 10 chars)
+	_file << "[" << padRight(fromNode, 10) << "]"
+		  << "[" << padRight(toNode, 10) << "] - ";
+
+	// Distance remaining
+	char distBuf[16];
+	std::snprintf(distBuf, sizeof(distBuf), "%05.2f", distRemainingKm);
+	_file << "[" << distBuf << "km] - ";
+
+	// Action (right-padded to 8 chars)
+	_file << "[" << padRight(action, 8) << "] - ";
+
+	// Rail graph: one cell per km
+	for (int km = 0; km < segmentCellsKm; km++)
+	{
+		bool isBlocking = false;
+		for (int bp : blockingCells)
+		{
+			if (bp == km)
+			{
+				isBlocking = true;
+				break;
+			}
+		}
+		if (km == positionCellKm)
+			_file << "[x]";
+		else if (isBlocking)
+			_file << "[O]";
+		else
+			_file << "[ ]";
+	}
+	_file << "\n";
+}
+
+void FileOutputObserver::onTrainEvent(const std::string &eventName,
+									  const std::string &nodeName,
+									  double delaySec)
+{
+	_file << "  ** EVENT: \"" << eventName << "\" at " << nodeName
+		  << " (+";
+	if (delaySec >= 3600.0)
+		_file << fmtTimeShort(delaySec);
+	else
+		_file << static_cast<int>(delaySec / 60) << "min";
+	_file << " delay)\n";
+}
+
+void FileOutputObserver::onTrainFinish(const std::string &trainName,
+									   double totalTimeSec)
+{
+	(void)trainName;
+	_file << "\nActual travel time : " << fmtTimeShort(totalTimeSec)
+		  << "m\n";
+	_file.flush();
+}
+
+const std::string &FileOutputObserver::getFilename() const
+{
+	return _filename;
+}

--- a/src/FileOutputObserver/FileOutputObserver.hpp
+++ b/src/FileOutputObserver/FileOutputObserver.hpp
@@ -1,0 +1,62 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   FileOutputObserver.hpp                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef FILEOUTPUTOBSERVER_HPP
+#define FILEOUTPUTOBSERVER_HPP
+
+#include <fstream>
+#include <string>
+
+#include "ISimulationObserver.hpp"
+
+/**
+ * Concrete Observer that writes per-train result files.
+ * Output filename: TrainName_DepartureTime.result
+ */
+class FileOutputObserver : public ISimulationObserver
+{
+  private:
+	std::ofstream _file;
+	std::string _filename;
+
+	static std::string buildFilename(const std::string &trainName,
+									 double departureTimeSec);
+	static std::string fmtTimeShort(double seconds);
+	static std::string padRight(const std::string &s, size_t width);
+
+  public:
+	FileOutputObserver(const std::string &trainName,
+					   double departureTimeSec);
+	FileOutputObserver(const FileOutputObserver &) = delete;
+	FileOutputObserver &operator=(const FileOutputObserver &) = delete;
+	~FileOutputObserver();
+
+	void onTrainStart(const std::string &trainName,
+					  double estimatedTimeSec) override;
+	void onTrainStep(double timeSinceStart,
+					 const std::string &fromNode,
+					 const std::string &toNode,
+					 double distRemainingKm,
+					 const std::string &action,
+					 int positionCellKm,
+					 int segmentCellsKm,
+					 const std::vector<int> &blockingCells) override;
+	void onTrainEvent(const std::string &eventName,
+					  const std::string &nodeName,
+					  double delaySec) override;
+	void onTrainFinish(const std::string &trainName,
+					   double totalTimeSec) override;
+
+	const std::string &getFilename() const;
+};
+
+#endif

--- a/src/ISimulationObserver/ISimulationObserver.hpp
+++ b/src/ISimulationObserver/ISimulationObserver.hpp
@@ -1,0 +1,54 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ISimulationObserver.hpp                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef ISIMULATIONOBSERVER_HPP
+#define ISIMULATIONOBSERVER_HPP
+
+#include <string>
+#include <vector>
+
+/**
+ * Observer interface for simulation events (Observer Design Pattern).
+ * Concrete observers receive real-time notifications as trains progress
+ * through the network, enabling decoupled output strategies (file, console,
+ * logging, etc.).
+ */
+class ISimulationObserver
+{
+  public:
+	virtual ~ISimulationObserver() = default;
+
+	/** Called once before the simulation loop starts for a train. */
+	virtual void onTrainStart(const std::string &trainName,
+							  double estimatedTimeSec) = 0;
+
+	/** Called at each output interval during the simulation. */
+	virtual void onTrainStep(double timeSinceStart,
+							 const std::string &fromNode,
+							 const std::string &toNode,
+							 double distRemainingKm,
+							 const std::string &action,
+							 int positionCellKm,
+							 int segmentCellsKm,
+							 const std::vector<int> &blockingCells) = 0;
+
+	/** Called when a random event triggers on a train. */
+	virtual void onTrainEvent(const std::string &eventName,
+							  const std::string &nodeName,
+							  double delaySec) = 0;
+
+	/** Called once when the train finishes its journey. */
+	virtual void onTrainFinish(const std::string &trainName,
+							   double totalTimeSec) = 0;
+};
+
+#endif

--- a/src/InputHandler/InputHandler.cpp
+++ b/src/InputHandler/InputHandler.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 10:00:00 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -173,14 +173,16 @@ std::vector<std::unique_ptr<Train>> InputHandler::parseTrainFile(
 
 		std::istringstream iss(line);
 		std::string name;
-		double accel, brake;
-		std::string departure, arrival, timeStr;
-		iss >> name >> accel >> brake >> departure >> arrival >> timeStr;
+		double weight, friction, accel, brake;
+		std::string departure, arrival, timeStr, stopStr;
+		iss >> name >> weight >> friction >> accel >> brake >> departure
+			>> arrival >> timeStr >> stopStr;
 		if (iss.fail() || name.empty() || departure.empty()
-			|| arrival.empty() || timeStr.empty())
+			|| arrival.empty() || timeStr.empty() || stopStr.empty())
 			throw ParseException("Invalid train line: " + line);
 		trains.push_back(TrainFactory::createTrain(
-			name, accel, brake, departure, arrival, parseTime(timeStr)));
+			name, weight, friction, accel, brake, departure, arrival,
+			parseTime(timeStr), parseTime(stopStr)));
 	}
 	return trains;
 }

--- a/src/Simulation/Simulation.cpp
+++ b/src/Simulation/Simulation.cpp
@@ -6,14 +6,18 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 10:34:58 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Simulation.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
+#include <limits>
+#include <map>
+#include <utility>
 
 #include "Node.hpp"
 
@@ -39,18 +43,210 @@ void Simulation::run()
 	computePaths();
 
 	std::cout << "=== Simulation ===" << std::endl;
+
+	/* Sort trains by departure time */
 	std::sort(_trains.begin(), _trains.end(),
 			  [](const auto &a, const auto &b) {
 				  return a->getDepartureTime() < b->getDepartureTime();
 			  });
 
+	/* Create per-train states and file-output observers */
+	std::vector<TrainState> states;
+	states.reserve(_trains.size());
+	_observers.clear();
+
 	for (auto &train : _trains)
-		simulateTrain(*train);
+	{
+		TrainState s{};
+		s.train = train.get();
+		s.segmentIndex = 0;
+		s.posOnSegment_m = 0.0;
+		s.speed_ms = 0.0;
+		s.timeSinceDepart = 0.0;
+		s.stopTimer = 0.0;
+		s.departed = false;
+		s.arrived = false;
+		states.push_back(s);
+
+		auto obs = std::make_unique<FileOutputObserver>(
+			train->getName(), train->getDepartureTime());
+		_observers.push_back(std::move(obs));
+	}
+
+	/* Write estimated travel times to result files */
+	for (size_t i = 0; i < states.size(); i++)
+	{
+		double est = estimateTravelTime(*states[i].train);
+		_observers[i]->onTrainStart(states[i].train->getName(), est);
+	}
+
+	/* Find earliest departure to start the clock */
+	double simTime = std::numeric_limits<double>::max();
+	for (auto &t : _trains)
+	{
+		if (t->getDepartureTime() < simTime)
+			simTime = t->getDepartureTime();
+	}
+	simTime -= DT;
+
+	/* Main concurrent simulation loop */
+	auto anyActive = [&]() {
+		for (auto &s : states)
+		{
+			if (!s.arrived)
+				return true;
+		}
+		return false;
+	};
+
+	while (anyActive())
+	{
+		simTime += DT;
+
+		for (size_t i = 0; i < states.size(); i++)
+		{
+			auto &s = states[i];
+			if (s.arrived)
+				continue;
+
+			/* Check departure */
+			if (!s.departed)
+			{
+				if (simTime >= s.train->getDepartureTime())
+				{
+					s.departed = true;
+					s.train->setStatus(TrainStatus::Running);
+					_output.printDeparture(*s.train);
+				}
+				continue;
+			}
+
+			/* Station stop countdown */
+			bool isStopped = false;
+			if (s.stopTimer > 0.0)
+			{
+				s.stopTimer -= DT;
+				if (s.stopTimer <= 0.0)
+					s.stopTimer = 0.0;
+				s.timeSinceDepart += DT;
+				s.train->setCurrentTime(s.train->getCurrentTime() + DT);
+				isStopped = true;
+			}
+
+			if (!isStopped)
+			{
+				/* Skip if path too short */
+				if (s.train->getPath().size() < 2)
+				{
+					s.arrived = true;
+					s.train->setStatus(TrainStatus::Arrived);
+					continue;
+				}
+
+				/* Physics step */
+				updatePhysics(s);
+				s.timeSinceDepart += DT;
+				s.train->setCurrentTime(s.train->getCurrentTime()
+										+ DT);
+
+				/* Segment transition */
+				auto &path = s.train->getPath();
+				double segLen_m, segSpd_ms;
+				getSegmentInfo(path[s.segmentIndex]->getName(),
+							   path[s.segmentIndex + 1]->getName(),
+							   segLen_m, segSpd_ms);
+
+				if (s.posOnSegment_m >= segLen_m)
+					handleSegmentTransition(s, i);
+			}
+
+			/* Output at intervals */
+			double modt = std::fmod(s.timeSinceDepart, OUTPUT_INTERVAL);
+			if (modt < DT || s.arrived)
+			{
+				double distRem = totalRemainingDistance(s) / 1000.0;
+				auto &p = s.train->getPath();
+				if (s.segmentIndex < p.size() - 1)
+				{
+					const std::string &from =
+						p[s.segmentIndex]->getName();
+					const std::string &to =
+						p[s.segmentIndex + 1]->getName();
+					double sLen_m, sSp_ms;
+					getSegmentInfo(from, to, sLen_m, sSp_ms);
+					int segKm = static_cast<int>(std::ceil(
+						sLen_m / 1000.0));
+					if (segKm < 1)
+						segKm = 1;
+					int posKm = static_cast<int>(
+						s.posOnSegment_m / 1000.0);
+					if (posKm >= segKm)
+						posKm = segKm - 1;
+
+					/* Find blocking trains on same segment */
+					std::vector<int> blocking;
+					for (size_t j = 0; j < states.size(); j++)
+					{
+						if (j == i || states[j].arrived
+							|| !states[j].departed)
+							continue;
+						auto &op = states[j].train->getPath();
+						if (states[j].segmentIndex < op.size() - 1
+							&& op[states[j].segmentIndex]->getName()
+								   == from
+							&& op[states[j].segmentIndex + 1]->getName()
+								   == to)
+						{
+							int oPos = static_cast<int>(
+								states[j].posOnSegment_m / 1000.0);
+							if (oPos >= segKm)
+								oPos = segKm - 1;
+							blocking.push_back(oPos);
+						}
+					}
+
+					std::string action;
+					if (isStopped)
+						action = " Stopped";
+					else if (s.arrived)
+						action = " Stopped";
+					else
+					{
+						double brakeDist = (s.speed_ms * s.speed_ms)
+										   / (2.0
+											  * s.train->getDecelRate());
+						double distToEnd = sLen_m - s.posOnSegment_m;
+						if (distToEnd <= brakeDist + 5.0
+							&& s.speed_ms > 0.1)
+							action = " Braking";
+						else if (s.speed_ms < sSp_ms - 0.5)
+							action = "Speed up";
+						else
+							action = "Maintain";
+					}
+
+					_observers[i]->onTrainStep(
+						s.timeSinceDepart, from, to, distRem, action,
+						posKm, segKm, blocking);
+				}
+			}
+		}
+
+		/* Overtaking / blocking check */
+		applyBlocking(states);
+	}
+
+	/* Finalize observer files */
+	for (size_t i = 0; i < states.size(); i++)
+	{
+		_observers[i]->onTrainFinish(states[i].train->getName(),
+									 states[i].timeSinceDepart);
+	}
 
 	_output.printResult(_trains);
 }
 
-/* ---- Private ---- */
+/* ---- Path computation ---- */
 void Simulation::computePaths()
 {
 	std::cout << "=== Paths ===" << std::endl;
@@ -72,48 +268,264 @@ void Simulation::computePaths()
 	std::cout << std::endl;
 }
 
-void Simulation::simulateTrain(Train &train)
+/* ---- Estimated travel time (analytical) ---- */
+double Simulation::estimateTravelTime(const Train &train) const
 {
 	const auto &path = train.getPath();
 	if (path.size() < 2)
-		return;
+		return 0.0;
 
-	train.setStatus(TrainStatus::Running);
-	_output.printDeparture(train);
+	double totalTime = 0.0;
+	double accel = train.getAccelRate();
+	double decel = train.getDecelRate();
 
 	for (size_t i = 0; i < path.size() - 1; i++)
 	{
-		const std::string &from = path[i]->getName();
-		const std::string &to = path[i + 1]->getName();
-		double travelTime = getEdgeTravelTime(from, to);
-		train.advanceToNextNode(travelTime);
-		_output.printArrival(train, to, train.getCurrentTime());
+		double segLen_m, speedLim_ms;
+		getSegmentInfo(path[i]->getName(), path[i + 1]->getName(),
+					   segLen_m, speedLim_ms);
 
-		auto nodeEvents = getEventsAtNode(to);
-		for (const auto *event : nodeEvents)
+		/* Time to accelerate from 0 to speed limit */
+		double tAccel = speedLim_ms / accel;
+		double dAccel = 0.5 * accel * tAccel * tAccel;
+
+		/* Time to brake from speed limit to 0 */
+		double tBrake = speedLim_ms / decel;
+		double dBrake = 0.5 * decel * tBrake * tBrake;
+
+		if (dAccel + dBrake > segLen_m)
 		{
-			if (event->tryTrigger(_rng))
-			{
-				train.applyDelay(event->getDuration());
-				_output.printEvent(*event, train);
-			}
+			/* Segment too short to reach full speed */
+			double vMax = std::sqrt(
+				2.0 * segLen_m * accel * decel / (accel + decel));
+			totalTime += vMax / accel + vMax / decel;
 		}
+		else
+		{
+			double dMaintain = segLen_m - dAccel - dBrake;
+			double tMaintain = dMaintain / speedLim_ms;
+			totalTime += tAccel + tMaintain + tBrake;
+		}
+
+		/* Add stop duration at intermediate stations */
+		if (i < path.size() - 2)
+			totalTime += train.getStopDuration();
 	}
-	std::cout << std::endl;
+	return totalTime;
 }
 
-double Simulation::getEdgeTravelTime(const std::string &from,
-									 const std::string &to) const
+/* ---- Segment info lookup ---- */
+void Simulation::getSegmentInfo(const std::string &from,
+								const std::string &to, double &length_m,
+								double &speedLimit_ms) const
 {
 	const auto &edges = _network.getNeighbours(from);
 	for (const auto &edge : edges)
 	{
 		if (edge.destination->getName() == to)
-			return (edge.distance / edge.speedLimit) * 3600.0;
+		{
+			length_m = edge.distance * 1000.0;
+			speedLimit_ms = edge.speedLimit / 3.6;
+			return;
+		}
 	}
 	throw std::runtime_error("No edge from " + from + " to " + to);
 }
 
+/* ---- Total remaining distance from current position ---- */
+double Simulation::totalRemainingDistance(const TrainState &s) const
+{
+	const auto &path = s.train->getPath();
+	if (s.segmentIndex >= path.size() - 1)
+		return 0.0;
+
+	/* Remaining on current segment */
+	double segLen_m, spd_ms;
+	getSegmentInfo(path[s.segmentIndex]->getName(),
+				   path[s.segmentIndex + 1]->getName(), segLen_m, spd_ms);
+	double remaining = segLen_m - s.posOnSegment_m;
+
+	/* Full lengths of subsequent segments */
+	for (size_t i = s.segmentIndex + 1; i < path.size() - 1; i++)
+	{
+		double sLen, sSp;
+		getSegmentInfo(path[i]->getName(), path[i + 1]->getName(), sLen,
+					   sSp);
+		remaining += sLen;
+	}
+	return remaining;
+}
+
+/* ---- Physics step (1 second) ---- */
+void Simulation::updatePhysics(TrainState &s)
+{
+	auto &path = s.train->getPath();
+	if (s.segmentIndex >= path.size() - 1)
+		return;
+
+	double segLen_m, speedLim_ms;
+	getSegmentInfo(path[s.segmentIndex]->getName(),
+				   path[s.segmentIndex + 1]->getName(), segLen_m,
+				   speedLim_ms);
+
+	double accel = s.train->getAccelRate();
+	double decel = s.train->getDecelRate();
+	double distToEnd = segLen_m - s.posOnSegment_m;
+
+	/* Determine target end speed: 0 at last segment, else next limit */
+	double targetEnd = 0.0;
+	bool isLast = (s.segmentIndex == path.size() - 2);
+	if (!isLast)
+	{
+		double nLen, nSpd;
+		getSegmentInfo(path[s.segmentIndex + 1]->getName(),
+					   path[s.segmentIndex + 2]->getName(), nLen, nSpd);
+		targetEnd = nSpd;
+		if (targetEnd > speedLim_ms)
+			targetEnd = speedLim_ms;
+	}
+
+	/* Braking distance needed to reach targetEnd */
+	double dv = s.speed_ms - targetEnd;
+	double brakeDist = 0.0;
+	if (dv > 0.0)
+		brakeDist = (s.speed_ms * s.speed_ms - targetEnd * targetEnd)
+					/ (2.0 * decel);
+
+	/* Decision */
+	double newSpeed = s.speed_ms;
+	if (distToEnd <= brakeDist + 2.0 && s.speed_ms > targetEnd + 0.1)
+	{
+		/* Brake */
+		newSpeed = s.speed_ms - decel * DT;
+		if (newSpeed < targetEnd)
+			newSpeed = targetEnd;
+		if (newSpeed < 0.0)
+			newSpeed = 0.0;
+	}
+	else if (s.speed_ms < speedLim_ms - 0.1)
+	{
+		/* Accelerate */
+		newSpeed = s.speed_ms + accel * DT;
+		if (newSpeed > speedLim_ms)
+			newSpeed = speedLim_ms;
+	}
+	else
+	{
+		/* Maintain */
+		newSpeed = speedLim_ms;
+	}
+
+	/* Update position */
+	double avgSpeed = (s.speed_ms + newSpeed) / 2.0;
+	double dist = avgSpeed * DT;
+	s.posOnSegment_m += dist;
+	s.speed_ms = newSpeed;
+
+	/* Clamp */
+	if (s.posOnSegment_m > segLen_m)
+		s.posOnSegment_m = segLen_m;
+}
+
+/* ---- Segment transition ---- */
+void Simulation::handleSegmentTransition(TrainState &s, size_t trainIdx)
+{
+	auto &path = s.train->getPath();
+	bool isLast = (s.segmentIndex >= path.size() - 2);
+
+	/* Notify arrival at next node */
+	std::string arrNode = path[s.segmentIndex + 1]->getName();
+	_output.printArrival(*s.train, arrNode, s.train->getCurrentTime());
+
+	/* Trigger events at this node */
+	auto nodeEvents = getEventsAtNode(arrNode);
+	for (const auto *event : nodeEvents)
+	{
+		if (event->tryTrigger(_rng))
+		{
+			double delay = event->getDuration();
+			s.train->applyDelay(delay);
+			s.timeSinceDepart += delay;
+			_output.printEvent(*event, *s.train);
+			_observers[trainIdx]->onTrainEvent(
+				event->getName(), event->getNodeName(), delay);
+		}
+	}
+
+	if (isLast)
+	{
+		/* Arrived at destination */
+		s.speed_ms = 0.0;
+		s.arrived = true;
+		s.train->setStatus(TrainStatus::Arrived);
+	}
+	else
+	{
+		/* Move to next segment */
+		s.segmentIndex++;
+		s.posOnSegment_m = 0.0;
+		s.train->setPathIndex(s.segmentIndex);
+
+		/* Apply stop duration at intermediate stations */
+		s.stopTimer = s.train->getStopDuration();
+	}
+}
+
+/* ---- Overtaking / blocking between trains ---- */
+void Simulation::applyBlocking(std::vector<TrainState> &states)
+{
+	/* For each pair of trains on the same segment, if one is behind
+	   and faster, cap its speed to the one ahead's speed. */
+	for (size_t i = 0; i < states.size(); i++)
+	{
+		if (states[i].arrived || !states[i].departed)
+			continue;
+		auto &pi = states[i].train->getPath();
+		if (states[i].segmentIndex >= pi.size() - 1)
+			continue;
+
+		const std::string &fromI =
+			pi[states[i].segmentIndex]->getName();
+		const std::string &toI =
+			pi[states[i].segmentIndex + 1]->getName();
+
+		for (size_t j = i + 1; j < states.size(); j++)
+		{
+			if (states[j].arrived || !states[j].departed)
+				continue;
+			auto &pj = states[j].train->getPath();
+			if (states[j].segmentIndex >= pj.size() - 1)
+				continue;
+
+			const std::string &fromJ =
+				pj[states[j].segmentIndex]->getName();
+			const std::string &toJ =
+				pj[states[j].segmentIndex + 1]->getName();
+
+			/* Same segment? */
+			if (fromI != fromJ || toI != toJ)
+				continue;
+
+			/* Determine who is ahead / behind */
+			TrainState *ahead = &states[i];
+			TrainState *behind = &states[j];
+			if (states[j].posOnSegment_m > states[i].posOnSegment_m)
+			{
+				ahead = &states[j];
+				behind = &states[i];
+			}
+
+			/* If behind is faster, cap its speed */
+			if (behind->speed_ms > ahead->speed_ms)
+			{
+				behind->speed_ms = ahead->speed_ms;
+				behind->train->setStatus(TrainStatus::Delayed);
+			}
+		}
+	}
+}
+
+/* ---- Events at a node ---- */
 std::vector<const Event *> Simulation::getEventsAtNode(
 	const std::string &nodeName) const
 {

--- a/src/Simulation/Simulation.hpp
+++ b/src/Simulation/Simulation.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Simulation.hpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,13 +15,31 @@
 
 #include <memory>
 #include <random>
+#include <string>
 #include <vector>
 
 #include "Event.hpp"
+#include "FileOutputObserver.hpp"
 #include "IPathfinding.hpp"
+#include "ISimulationObserver.hpp"
 #include "OutputManager.hpp"
 #include "RailNetwork.hpp"
 #include "Train.hpp"
+
+/**
+ * Per-train runtime state used during the discrete simulation.
+ */
+struct TrainState
+{
+	Train *train;
+	size_t segmentIndex;     // current segment (0 = first edge)
+	double posOnSegment_m;   // metres from start of current segment
+	double speed_ms;         // current speed in m/s
+	double timeSinceDepart;  // seconds since this train departed
+	double stopTimer;        // seconds remaining at a station stop
+	bool departed;
+	bool arrived;
+};
 
 class Simulation
 {
@@ -32,6 +50,10 @@ class Simulation
 	std::unique_ptr<IPathfinding> _pathfinder;
 	OutputManager _output;
 	std::mt19937 _rng;
+	std::vector<std::unique_ptr<ISimulationObserver>> _observers;
+
+	static constexpr double DT = 1.0;             // 1-second timestep
+	static constexpr double OUTPUT_INTERVAL = 60.0; // output every minute
 
   public:
 	Simulation(RailNetwork network,
@@ -46,9 +68,13 @@ class Simulation
 
   private:
 	void computePaths();
-	void simulateTrain(Train &train);
-	double getEdgeTravelTime(const std::string &from,
-							 const std::string &to) const;
+	double estimateTravelTime(const Train &train) const;
+	void getSegmentInfo(const std::string &from, const std::string &to,
+						double &length_m, double &speedLimit_ms) const;
+	double totalRemainingDistance(const TrainState &s) const;
+	void updatePhysics(TrainState &s);
+	void handleSegmentTransition(TrainState &s, size_t trainIdx);
+	void applyBlocking(std::vector<TrainState> &states);
 	std::vector<const Event *> getEventsAtNode(
 		const std::string &nodeName) const;
 };

--- a/src/Train/Train.cpp
+++ b/src/Train/Train.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,25 +15,33 @@
 #include "Node.hpp"
 
 /* ---- Canonical form ---- */
-Train::Train(const std::string &name, double acceleration, double braking,
+Train::Train(const std::string &name, double weight, double friction,
+			 double accelForce, double brakeForce,
 			 const std::string &departure, const std::string &arrival,
-			 double departureTime)
-	: _name(name), _maxAcceleration(acceleration),
-	  _maxBrakingForce(braking), _departureStation(departure),
-	  _arrivalStation(arrival), _departureTime(departureTime),
+			 double departureTime, double stopDuration)
+	: _name(name), _weight(weight), _frictionCoefficient(friction),
+	  _maxAccelForce(accelForce), _maxBrakeForce(brakeForce),
+	  _departureStation(departure), _arrivalStation(arrival),
+	  _departureTime(departureTime), _stopDuration(stopDuration),
 	  _status(TrainStatus::Waiting), _pathIndex(0),
-	  _currentTime(departureTime), _totalDelay(0.0)
+	  _currentTime(departureTime), _totalDelay(0.0),
+	  _currentSpeed(0.0), _posOnSegment(0.0)
 {
 }
 
 Train::Train(const Train &src)
-	: _name(src._name), _maxAcceleration(src._maxAcceleration),
-	  _maxBrakingForce(src._maxBrakingForce),
+	: _name(src._name), _weight(src._weight),
+	  _frictionCoefficient(src._frictionCoefficient),
+	  _maxAccelForce(src._maxAccelForce),
+	  _maxBrakeForce(src._maxBrakeForce),
 	  _departureStation(src._departureStation),
 	  _arrivalStation(src._arrivalStation),
-	  _departureTime(src._departureTime), _status(src._status),
+	  _departureTime(src._departureTime),
+	  _stopDuration(src._stopDuration), _status(src._status),
 	  _path(src._path), _pathIndex(src._pathIndex),
-	  _currentTime(src._currentTime), _totalDelay(src._totalDelay)
+	  _currentTime(src._currentTime), _totalDelay(src._totalDelay),
+	  _currentSpeed(src._currentSpeed),
+	  _posOnSegment(src._posOnSegment)
 {
 }
 
@@ -42,16 +50,21 @@ Train &Train::operator=(const Train &src)
 	if (this != &src)
 	{
 		_name = src._name;
-		_maxAcceleration = src._maxAcceleration;
-		_maxBrakingForce = src._maxBrakingForce;
+		_weight = src._weight;
+		_frictionCoefficient = src._frictionCoefficient;
+		_maxAccelForce = src._maxAccelForce;
+		_maxBrakeForce = src._maxBrakeForce;
 		_departureStation = src._departureStation;
 		_arrivalStation = src._arrivalStation;
 		_departureTime = src._departureTime;
+		_stopDuration = src._stopDuration;
 		_status = src._status;
 		_path = src._path;
 		_pathIndex = src._pathIndex;
 		_currentTime = src._currentTime;
 		_totalDelay = src._totalDelay;
+		_currentSpeed = src._currentSpeed;
+		_posOnSegment = src._posOnSegment;
 	}
 	return *this;
 }
@@ -84,11 +97,22 @@ void Train::applyDelay(double seconds)
 }
 
 void Train::setStatus(TrainStatus status) { _status = status; }
+void Train::setCurrentSpeed(double speed) { _currentSpeed = speed; }
+void Train::setPosOnSegment(double pos) { _posOnSegment = pos; }
+void Train::setPathIndex(size_t idx) { _pathIndex = idx; }
+void Train::setCurrentTime(double t) { _currentTime = t; }
 
 /* ---- Getters ---- */
 const std::string &Train::getName() const { return _name; }
-double Train::getMaxAcceleration() const { return _maxAcceleration; }
-double Train::getMaxBrakingForce() const { return _maxBrakingForce; }
+double Train::getWeight() const { return _weight; }
+
+double Train::getFrictionCoefficient() const
+{
+	return _frictionCoefficient;
+}
+
+double Train::getMaxAccelForce() const { return _maxAccelForce; }
+double Train::getMaxBrakeForce() const { return _maxBrakeForce; }
 
 const std::string &Train::getDepartureStation() const
 {
@@ -101,6 +125,7 @@ const std::string &Train::getArrivalStation() const
 }
 
 double Train::getDepartureTime() const { return _departureTime; }
+double Train::getStopDuration() const { return _stopDuration; }
 TrainStatus Train::getStatus() const { return _status; }
 
 const std::vector<std::shared_ptr<Node>> &Train::getPath() const
@@ -111,6 +136,8 @@ const std::vector<std::shared_ptr<Node>> &Train::getPath() const
 size_t Train::getPathIndex() const { return _pathIndex; }
 double Train::getCurrentTime() const { return _currentTime; }
 double Train::getTotalDelay() const { return _totalDelay; }
+double Train::getCurrentSpeed() const { return _currentSpeed; }
+double Train::getPosOnSegment() const { return _posOnSegment; }
 
 std::string Train::getCurrentNodeName() const
 {
@@ -122,6 +149,24 @@ std::string Train::getCurrentNodeName() const
 bool Train::hasArrived() const
 {
 	return _status == TrainStatus::Arrived;
+}
+
+/* ---- Physics helpers ---- */
+double Train::getAccelRate() const
+{
+	double mass_kg = _weight * 1000.0;
+	double friction_N = _frictionCoefficient * mass_kg * 9.81;
+	double force_N = _maxAccelForce * 1000.0;
+	double net = force_N - friction_N;
+	return (net > 0.0) ? net / mass_kg : 0.0;
+}
+
+double Train::getDecelRate() const
+{
+	double mass_kg = _weight * 1000.0;
+	double friction_N = _frictionCoefficient * mass_kg * 9.81;
+	double force_N = _maxBrakeForce * 1000.0;
+	return (force_N + friction_N) / mass_kg;
 }
 
 std::string Train::statusToString(TrainStatus status)

--- a/src/Train/Train.hpp
+++ b/src/Train/Train.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Train.hpp                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,22 +31,28 @@ class Train
 {
   private:
 	std::string _name;
-	double _maxAcceleration;
-	double _maxBrakingForce;
+	double _weight;             // metric tons
+	double _frictionCoefficient;
+	double _maxAccelForce;      // kilonewtons
+	double _maxBrakeForce;      // kilonewtons
 	std::string _departureStation;
 	std::string _arrivalStation;
-	double _departureTime;
+	double _departureTime;      // seconds from midnight
+	double _stopDuration;       // seconds at each station
 
 	TrainStatus _status;
 	std::vector<std::shared_ptr<Node>> _path;
 	size_t _pathIndex;
 	double _currentTime;
 	double _totalDelay;
+	double _currentSpeed;       // m/s
+	double _posOnSegment;       // metres on current segment
 
   public:
-	Train(const std::string &name, double acceleration, double braking,
+	Train(const std::string &name, double weight, double friction,
+		  double accelForce, double brakeForce,
 		  const std::string &departure, const std::string &arrival,
-		  double departureTime);
+		  double departureTime, double stopDuration);
 	Train(const Train &src);
 	Train &operator=(const Train &src);
 	~Train();
@@ -55,20 +61,32 @@ class Train
 	void advanceToNextNode(double travelTime);
 	void applyDelay(double seconds);
 	void setStatus(TrainStatus status);
+	void setCurrentSpeed(double speed);
+	void setPosOnSegment(double pos);
+	void setPathIndex(size_t idx);
+	void setCurrentTime(double t);
 
 	const std::string &getName() const;
-	double getMaxAcceleration() const;
-	double getMaxBrakingForce() const;
+	double getWeight() const;
+	double getFrictionCoefficient() const;
+	double getMaxAccelForce() const;
+	double getMaxBrakeForce() const;
 	const std::string &getDepartureStation() const;
 	const std::string &getArrivalStation() const;
 	double getDepartureTime() const;
+	double getStopDuration() const;
 	TrainStatus getStatus() const;
 	const std::vector<std::shared_ptr<Node>> &getPath() const;
 	size_t getPathIndex() const;
 	double getCurrentTime() const;
 	double getTotalDelay() const;
+	double getCurrentSpeed() const;
+	double getPosOnSegment() const;
 	std::string getCurrentNodeName() const;
 	bool hasArrived() const;
+
+	double getAccelRate() const;
+	double getDecelRate() const;
 
 	static std::string statusToString(TrainStatus status);
 };

--- a/src/TrainFactory/TrainFactory.cpp
+++ b/src/TrainFactory/TrainFactory.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,15 +15,20 @@
 #include <stdexcept>
 
 std::unique_ptr<Train> TrainFactory::createTrain(
-	const std::string &name, double acceleration, double braking,
+	const std::string &name, double weight, double friction,
+	double accelForce, double brakeForce,
 	const std::string &departure, const std::string &arrival,
-	double departureTime)
+	double departureTime, double stopDuration)
 {
 	if (name.empty())
 		throw std::invalid_argument("Train name cannot be empty");
-	if (acceleration <= 0.0)
-		throw std::invalid_argument("Acceleration must be positive");
-	if (braking <= 0.0)
+	if (weight <= 0.0)
+		throw std::invalid_argument("Weight must be positive");
+	if (friction < 0.0)
+		throw std::invalid_argument("Friction coefficient cannot be negative");
+	if (accelForce <= 0.0)
+		throw std::invalid_argument("Acceleration force must be positive");
+	if (brakeForce <= 0.0)
 		throw std::invalid_argument("Braking force must be positive");
 	if (departure.empty() || arrival.empty())
 		throw std::invalid_argument("Station names cannot be empty");
@@ -31,6 +36,9 @@ std::unique_ptr<Train> TrainFactory::createTrain(
 		throw std::invalid_argument("Departure and arrival must differ");
 	if (departureTime < 0.0)
 		throw std::invalid_argument("Departure time cannot be negative");
-	return std::make_unique<Train>(name, acceleration, braking, departure,
-								   arrival, departureTime);
+	if (stopDuration < 0.0)
+		throw std::invalid_argument("Stop duration cannot be negative");
+	return std::make_unique<Train>(name, weight, friction, accelForce,
+								   brakeForce, departure, arrival,
+								   departureTime, stopDuration);
 }

--- a/src/TrainFactory/TrainFactory.hpp
+++ b/src/TrainFactory/TrainFactory.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   TrainFactory.hpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,9 +24,10 @@ class TrainFactory
 	TrainFactory() = delete;
 
 	static std::unique_ptr<Train> createTrain(
-		const std::string &name, double acceleration, double braking,
+		const std::string &name, double weight, double friction,
+		double accelForce, double brakeForce,
 		const std::string &departure, const std::string &arrival,
-		double departureTime);
+		double departureTime, double stopDuration);
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 02:45:00 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <memory>
 
@@ -18,12 +19,52 @@
 #include "InputHandler.hpp"
 #include "Simulation.hpp"
 
+static void printHelp()
+{
+	std::cout
+		<< "Usage: ./Train <network_file> <train_file>\n\n"
+		<< "=== Network file format ===\n"
+		<< "  Node <name>\n"
+		<< "    Declares a station or junction in the network.\n\n"
+		<< "  Rail <from> <to> <distance_km> <speed_limit_kmh>\n"
+		<< "    Creates a bidirectional track between two nodes.\n\n"
+		<< "  Event <name> <probability> <duration> <node_name>\n"
+		<< "    Adds a random event at a node. Duration units: m/h/d.\n"
+		<< "    Quoted names are supported: \"Passenger's Discomfort\"\n\n"
+		<< "=== Train file format ===\n"
+		<< "  <name> <weight_t> <friction> <accel_kN> <brake_kN> "
+		<< "<from> <to> <departure_time> <stop_duration>\n"
+		<< "    Example: TrainAB 80 0.05 356.0 30.0 CityA CityB "
+		<< "14h10 00h10\n\n"
+		<< "  Fields:\n"
+		<< "    name            - Train identifier\n"
+		<< "    weight_t        - Weight in metric tons\n"
+		<< "    friction        - Coefficient of friction\n"
+		<< "    accel_kN        - Max acceleration force (kilonewtons)\n"
+		<< "    brake_kN        - Max braking force (kilonewtons)\n"
+		<< "    from            - Departure station\n"
+		<< "    to              - Arrival station\n"
+		<< "    departure_time  - Departure time (e.g. 14h10)\n"
+		<< "    stop_duration   - Duration of stop at each station "
+		<< "(e.g. 00h10)\n\n"
+		<< "=== Output ===\n"
+		<< "  The program generates one .result file per train:\n"
+		<< "    TrainName_DepartureTime.result\n";
+}
+
 int main(int argc, char **argv)
 {
+	if (argc == 2 && std::strcmp(argv[1], "--help") == 0)
+	{
+		printHelp();
+		return EXIT_SUCCESS;
+	}
 	if (argc != 3)
 	{
 		std::cerr << "Usage: " << argv[0]
 				  << " <network_file> <train_file>" << std::endl;
+		std::cerr << "Use --help for detailed format information."
+				  << std::endl;
 		return EXIT_FAILURE;
 	}
 

--- a/tests/InputHandlerTest.cpp
+++ b/tests/InputHandlerTest.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 10:02:58 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,9 +49,34 @@ int main()
 					  "input/railNetworkPrintFolder/"
 					  "railNetworkPrintGood.txt",
 					  "input/trainPrintFolder/trainPrintGood.txt");
-				  // TrainAB1 departs at 14h10 = 14*3600 + 10*60 = 51000
+				  // TrainAB departs at 14h10 = 14*3600 + 10*60 = 51000
 				  ASSERT_TRUE(data.trains[0]->getDepartureTime() == 51000.0,
 							  msg);
+				  return true;
+			  });
+
+	suite.run("train has correct weight and friction",
+			  [](std::string &msg) {
+				  auto data = InputHandler::loadData(
+					  "input/railNetworkPrintFolder/"
+					  "railNetworkPrintGood.txt",
+					  "input/trainPrintFolder/trainPrintGood.txt");
+				  ASSERT_TRUE(data.trains[0]->getWeight() == 80.0, msg);
+				  ASSERT_TRUE(
+					  data.trains[0]->getFrictionCoefficient() == 0.05,
+					  msg);
+				  return true;
+			  });
+
+	suite.run("train has correct stop duration",
+			  [](std::string &msg) {
+				  auto data = InputHandler::loadData(
+					  "input/railNetworkPrintFolder/"
+					  "railNetworkPrintGood.txt",
+					  "input/trainPrintFolder/trainPrintGood.txt");
+				  // 00h10 = 600 seconds
+				  ASSERT_TRUE(
+					  data.trains[0]->getStopDuration() == 600.0, msg);
 				  return true;
 			  });
 

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -6,16 +6,26 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 04:01:26 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 10:02:58 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <cstdio>
+#include <fstream>
 #include <memory>
+#include <string>
 
 #include "DijkstraPathfinding.hpp"
 #include "InputHandler.hpp"
 #include "Simulation.hpp"
 #include "TestFramework.hpp"
+
+static void cleanupResults()
+{
+	std::remove("TrainAB_14h10.result");
+	std::remove("TrainAC_14h20.result");
+	std::remove("TrainBA_14h24.result");
+}
 
 int main()
 {
@@ -23,6 +33,7 @@ int main()
 
 	suite.run("full simulation runs without crash",
 			  [](std::string &msg) {
+				  cleanupResults();
 				  auto data = InputHandler::loadData(
 					  "input/railNetworkPrintFolder/"
 					  "railNetworkPrintGood.txt",
@@ -38,11 +49,11 @@ int main()
 
 	suite.run("all trains arrive after simulation",
 			  [](std::string &msg) {
+				  cleanupResults();
 				  auto data = InputHandler::loadData(
 					  "input/railNetworkPrintFolder/"
 					  "railNetworkPrintGood.txt",
 					  "input/trainPrintFolder/trainPrintGood.txt");
-				  // Keep raw pointers before moving
 				  std::vector<Train *> refs;
 				  for (auto &t : data.trains)
 					  refs.push_back(t.get());
@@ -60,6 +71,7 @@ int main()
 
 	suite.run("trains have non-zero arrival times",
 			  [](std::string &msg) {
+				  cleanupResults();
 				  auto data = InputHandler::loadData(
 					  "input/railNetworkPrintFolder/"
 					  "railNetworkPrintGood.txt",
@@ -81,6 +93,7 @@ int main()
 
 	suite.run("departure time <= arrival time for all trains",
 			  [](std::string &msg) {
+				  cleanupResults();
 				  auto data = InputHandler::loadData(
 					  "input/railNetworkPrintFolder/"
 					  "railNetworkPrintGood.txt",
@@ -104,6 +117,7 @@ int main()
 
 	suite.run("paths have at least 2 nodes",
 			  [](std::string &msg) {
+				  cleanupResults();
 				  auto data = InputHandler::loadData(
 					  "input/railNetworkPrintFolder/"
 					  "railNetworkPrintGood.txt",
@@ -123,5 +137,51 @@ int main()
 				  return true;
 			  });
 
+	suite.run("result files are created",
+			  [](std::string &msg) {
+				  cleanupResults();
+				  auto data = InputHandler::loadData(
+					  "input/railNetworkPrintFolder/"
+					  "railNetworkPrintGood.txt",
+					  "input/trainPrintFolder/trainPrintGood.txt");
+				  Simulation sim(
+					  std::move(data.network), std::move(data.trains),
+					  std::move(data.events),
+					  std::make_unique<DijkstraPathfinding>());
+				  sim.run();
+				  std::ifstream f1("TrainAB_14h10.result");
+				  ASSERT_TRUE(f1.is_open(), msg);
+				  std::ifstream f2("TrainAC_14h20.result");
+				  ASSERT_TRUE(f2.is_open(), msg);
+				  std::ifstream f3("TrainBA_14h24.result");
+				  ASSERT_TRUE(f3.is_open(), msg);
+				  return true;
+			  });
+
+	suite.run("result file contains train name and travel time",
+			  [](std::string &msg) {
+				  cleanupResults();
+				  auto data = InputHandler::loadData(
+					  "input/railNetworkPrintFolder/"
+					  "railNetworkPrintGood.txt",
+					  "input/trainPrintFolder/trainPrintGood.txt");
+				  Simulation sim(
+					  std::move(data.network), std::move(data.trains),
+					  std::move(data.events),
+					  std::make_unique<DijkstraPathfinding>());
+				  sim.run();
+				  std::ifstream f("TrainAB_14h10.result");
+				  std::string line;
+				  std::getline(f, line);
+				  ASSERT_TRUE(line.find("TrainAB") != std::string::npos,
+							  msg);
+				  std::getline(f, line);
+				  ASSERT_TRUE(
+					  line.find("Final travel time") != std::string::npos,
+					  msg);
+				  return true;
+			  });
+
+	cleanupResults();
 	return suite.summarize();
 }

--- a/tests/TrainFactoryTest.cpp
+++ b/tests/TrainFactoryTest.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 03:24:01 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 10:02:58 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,46 +18,62 @@ int main()
 	Test::TestSuite suite("TrainFactory");
 
 	suite.run("creates valid train", [](std::string &msg) {
-		auto t = TrainFactory::createTrain("Express", 1.5, 1.2, "A", "B",
-										   3600.0);
+		auto t = TrainFactory::createTrain("Express", 80.0, 0.05, 356.0,
+										   30.0, "A", "B", 3600.0, 600.0);
 		ASSERT_TRUE(t != nullptr, msg);
 		ASSERT_STR_EQ(std::string("Express"), t->getName(), msg);
-		ASSERT_TRUE(t->getMaxAcceleration() == 1.5, msg);
-		ASSERT_TRUE(t->getMaxBrakingForce() == 1.2, msg);
+		ASSERT_TRUE(t->getWeight() == 80.0, msg);
+		ASSERT_TRUE(t->getFrictionCoefficient() == 0.05, msg);
+		ASSERT_TRUE(t->getMaxAccelForce() == 356.0, msg);
+		ASSERT_TRUE(t->getMaxBrakeForce() == 30.0, msg);
+		ASSERT_TRUE(t->getStopDuration() == 600.0, msg);
 		return true;
 	});
 
 	suite.run("throws on empty name", [](std::string &msg) {
 		ASSERT_THROWS(
-			TrainFactory::createTrain("", 1.0, 1.0, "A", "B", 0.0),
+			TrainFactory::createTrain("", 80.0, 0.05, 356.0, 30.0,
+									  "A", "B", 0.0, 0.0),
 			std::invalid_argument, msg);
 		return true;
 	});
 
-	suite.run("throws on zero acceleration", [](std::string &msg) {
+	suite.run("throws on zero weight", [](std::string &msg) {
 		ASSERT_THROWS(
-			TrainFactory::createTrain("T", 0.0, 1.0, "A", "B", 0.0),
+			TrainFactory::createTrain("T", 0.0, 0.05, 356.0, 30.0,
+									  "A", "B", 0.0, 0.0),
 			std::invalid_argument, msg);
 		return true;
 	});
 
-	suite.run("throws on negative acceleration", [](std::string &msg) {
+	suite.run("throws on negative friction", [](std::string &msg) {
 		ASSERT_THROWS(
-			TrainFactory::createTrain("T", -1.0, 1.0, "A", "B", 0.0),
+			TrainFactory::createTrain("T", 80.0, -0.05, 356.0, 30.0,
+									  "A", "B", 0.0, 0.0),
 			std::invalid_argument, msg);
 		return true;
 	});
 
-	suite.run("throws on zero braking", [](std::string &msg) {
+	suite.run("throws on zero acceleration force", [](std::string &msg) {
 		ASSERT_THROWS(
-			TrainFactory::createTrain("T", 1.0, 0.0, "A", "B", 0.0),
+			TrainFactory::createTrain("T", 80.0, 0.05, 0.0, 30.0,
+									  "A", "B", 0.0, 0.0),
+			std::invalid_argument, msg);
+		return true;
+	});
+
+	suite.run("throws on zero braking force", [](std::string &msg) {
+		ASSERT_THROWS(
+			TrainFactory::createTrain("T", 80.0, 0.05, 356.0, 0.0,
+									  "A", "B", 0.0, 0.0),
 			std::invalid_argument, msg);
 		return true;
 	});
 
 	suite.run("throws on empty departure", [](std::string &msg) {
 		ASSERT_THROWS(
-			TrainFactory::createTrain("T", 1.0, 1.0, "", "B", 0.0),
+			TrainFactory::createTrain("T", 80.0, 0.05, 356.0, 30.0,
+									  "", "B", 0.0, 0.0),
 			std::invalid_argument, msg);
 		return true;
 	});
@@ -65,7 +81,8 @@ int main()
 	suite.run("throws on same departure and arrival",
 			  [](std::string &msg) {
 				  ASSERT_THROWS(
-					  TrainFactory::createTrain("T", 1.0, 1.0, "A", "A",
+					  TrainFactory::createTrain("T", 80.0, 0.05, 356.0,
+												30.0, "A", "A", 0.0,
 												0.0),
 					  std::invalid_argument, msg);
 				  return true;
@@ -74,8 +91,19 @@ int main()
 	suite.run("throws on negative departure time",
 			  [](std::string &msg) {
 				  ASSERT_THROWS(
-					  TrainFactory::createTrain("T", 1.0, 1.0, "A", "B",
-												-100.0),
+					  TrainFactory::createTrain("T", 80.0, 0.05, 356.0,
+												30.0, "A", "B", -100.0,
+												0.0),
+					  std::invalid_argument, msg);
+				  return true;
+			  });
+
+	suite.run("throws on negative stop duration",
+			  [](std::string &msg) {
+				  ASSERT_THROWS(
+					  TrainFactory::createTrain("T", 80.0, 0.05, 356.0,
+												30.0, "A", "B", 0.0,
+												-1.0),
 					  std::invalid_argument, msg);
 				  return true;
 			  });

--- a/tests/TrainTest.cpp
+++ b/tests/TrainTest.cpp
@@ -6,10 +6,11 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 03:22:12 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 10:02:58 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <cmath>
 #include <memory>
 
 #include "Node.hpp"
@@ -21,19 +22,23 @@ int main()
 	Test::TestSuite suite("Train");
 
 	suite.run("constructor sets all fields", [](std::string &msg) {
-		Train t("Express", 1.5, 1.2, "CityA", "CityB", 50400.0);
+		Train t("Express", 80.0, 0.05, 356.0, 30.0, "CityA", "CityB",
+				50400.0, 600.0);
 		ASSERT_STR_EQ(std::string("Express"), t.getName(), msg);
-		ASSERT_TRUE(t.getMaxAcceleration() == 1.5, msg);
-		ASSERT_TRUE(t.getMaxBrakingForce() == 1.2, msg);
+		ASSERT_TRUE(t.getWeight() == 80.0, msg);
+		ASSERT_TRUE(t.getFrictionCoefficient() == 0.05, msg);
+		ASSERT_TRUE(t.getMaxAccelForce() == 356.0, msg);
+		ASSERT_TRUE(t.getMaxBrakeForce() == 30.0, msg);
 		ASSERT_STR_EQ(std::string("CityA"), t.getDepartureStation(), msg);
 		ASSERT_STR_EQ(std::string("CityB"), t.getArrivalStation(), msg);
 		ASSERT_TRUE(t.getDepartureTime() == 50400.0, msg);
+		ASSERT_TRUE(t.getStopDuration() == 600.0, msg);
 		ASSERT_TRUE(t.getStatus() == TrainStatus::Waiting, msg);
 		return true;
 	});
 
 	suite.run("setPath and getPath work", [](std::string &msg) {
-		Train t("T1", 1.0, 1.0, "A", "C", 0.0);
+		Train t("T1", 80.0, 0.05, 356.0, 30.0, "A", "C", 0.0, 0.0);
 		auto a = std::make_shared<Node>("A");
 		auto b = std::make_shared<Node>("B");
 		auto c = std::make_shared<Node>("C");
@@ -44,7 +49,7 @@ int main()
 	});
 
 	suite.run("advanceToNextNode updates state", [](std::string &msg) {
-		Train t("T2", 1.0, 1.0, "A", "C", 1000.0);
+		Train t("T2", 80.0, 0.05, 356.0, 30.0, "A", "C", 1000.0, 0.0);
 		auto a = std::make_shared<Node>("A");
 		auto b = std::make_shared<Node>("B");
 		auto c = std::make_shared<Node>("C");
@@ -58,7 +63,8 @@ int main()
 
 	suite.run("advanceToNextNode marks arrived at end",
 			  [](std::string &msg) {
-				  Train t("T3", 1.0, 1.0, "A", "B", 0.0);
+				  Train t("T3", 80.0, 0.05, 356.0, 30.0, "A", "B",
+						  0.0, 0.0);
 				  auto a = std::make_shared<Node>("A");
 				  auto b = std::make_shared<Node>("B");
 				  t.setPath({a, b});
@@ -68,7 +74,7 @@ int main()
 			  });
 
 	suite.run("applyDelay accumulates", [](std::string &msg) {
-		Train t("T4", 1.0, 1.0, "A", "B", 0.0);
+		Train t("T4", 80.0, 0.05, 356.0, 30.0, "A", "B", 0.0, 0.0);
 		t.applyDelay(60.0);
 		t.applyDelay(120.0);
 		ASSERT_TRUE(t.getTotalDelay() == 180.0, msg);
@@ -77,10 +83,13 @@ int main()
 	});
 
 	suite.run("copy constructor works", [](std::string &msg) {
-		Train original("Orig", 2.0, 1.5, "X", "Y", 3600.0);
+		Train original("Orig", 60.0, 0.04, 412.0, 40.0, "X", "Y",
+					   3600.0, 600.0);
 		Train copy(original);
 		ASSERT_STR_EQ(original.getName(), copy.getName(), msg);
 		ASSERT_TRUE(copy.getDepartureTime() == 3600.0, msg);
+		ASSERT_TRUE(copy.getWeight() == 60.0, msg);
+		ASSERT_TRUE(copy.getStopDuration() == 600.0, msg);
 		return true;
 	});
 
@@ -108,14 +117,17 @@ int main()
 
 	suite.run("getCurrentNodeName empty path returns empty",
 			  [](std::string &msg) {
-				  Train t("T", 1.0, 1.0, "A", "B", 0.0);
-				  ASSERT_STR_EQ(std::string(""), t.getCurrentNodeName(), msg);
+				  Train t("T", 80.0, 0.05, 356.0, 30.0, "A", "B",
+						  0.0, 0.0);
+				  ASSERT_STR_EQ(std::string(""), t.getCurrentNodeName(),
+								msg);
 				  return true;
 			  });
 
 	suite.run("advanceToNextNode on empty path is safe",
 			  [](std::string &msg) {
-				  Train t("T", 1.0, 1.0, "A", "B", 0.0);
+				  Train t("T", 80.0, 0.05, 356.0, 30.0, "A", "B",
+						  0.0, 0.0);
 				  t.advanceToNextNode(100.0);
 				  ASSERT_EQ(0u, t.getPathIndex(), msg);
 				  return true;
@@ -123,10 +135,40 @@ int main()
 
 	suite.run("hasArrived is false after construction",
 			  [](std::string &msg) {
-				  Train t("T", 1.0, 1.0, "A", "B", 0.0);
+				  Train t("T", 80.0, 0.05, 356.0, 30.0, "A", "B",
+						  0.0, 0.0);
 				  ASSERT_FALSE(t.hasArrived(), msg);
 				  return true;
 			  });
+
+	suite.run("getAccelRate returns correct value",
+			  [](std::string &msg) {
+				  Train t("T", 80.0, 0.05, 356.0, 30.0, "A", "B",
+						  0.0, 0.0);
+				  double rate = t.getAccelRate();
+				  // F_net = 356000 - 0.05*80000*9.81 = 356000 - 39240
+				  // a = 316760 / 80000 = 3.9595 m/s^2
+				  ASSERT_TRUE(std::fabs(rate - 3.9595) < 0.01, msg);
+				  return true;
+			  });
+
+	suite.run("getDecelRate returns correct value",
+			  [](std::string &msg) {
+				  Train t("T", 80.0, 0.05, 356.0, 30.0, "A", "B",
+						  0.0, 0.0);
+				  double rate = t.getDecelRate();
+				  // decel = (30000 + 0.05*80000*9.81) / 80000
+				  //       = (30000 + 39240) / 80000 = 0.8655
+				  ASSERT_TRUE(std::fabs(rate - 0.8655) < 0.01, msg);
+				  return true;
+			  });
+
+	suite.run("currentSpeed initially zero", [](std::string &msg) {
+		Train t("T", 80.0, 0.05, 356.0, 30.0, "A", "B", 0.0, 0.0);
+		ASSERT_TRUE(t.getCurrentSpeed() == 0.0, msg);
+		ASSERT_TRUE(t.getPosOnSegment() == 0.0, msg);
+		return true;
+	});
 
 	return suite.summarize();
 }


### PR DESCRIPTION
## Description

Full spec compliance for Module 05. Major changes:

- **Train model**: added weight (tons), friction coefficient, accel/brake forces (kN), stop duration. Physics helpers: `getAccelRate()`, `getDecelRate()`.
- **TrainFactory**: 9-parameter creation with validation for all new fields.
- **Observer pattern** (3rd design pattern): `ISimulationObserver` interface + `FileOutputObserver` concrete class for per-train `.result` file output.
- **Simulation rewrite**: real physics engine (F=ma with friction μmg), concurrent multi-train loop, overtaking/blocking system, station stops with configurable duration.
- **Per-train .result files**: `TrainName_DepartureTime.result` with estimated travel time header, timestep logs every minute (including during stops), rail graph (`[x]` position, `[O]` blocking), event notifications, actual travel time footer.
- **InputHandler**: 9-field train format (`name weight friction accel brake from to time stop`).
- **`--help` flag** with full format documentation for network and train files.
- **`.gitignore`**: exclude `*.result` output files.

Design patterns: Strategy (IPathfinding→Dijkstra), Factory (TrainFactory), Observer (ISimulationObserver→FileOutputObserver).

## Screenshots

```
Train : TrainAB
Final travel time : 00h34m

[00h01] - [     CityA][ RailNodeA] - [41.46km] - [Maintain] - [ ][ ][ ][x][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ]
[00h04] - [ RailNodeA][ RailNodeD] - [30.02km] - [ Stopped] - [x][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ]
[00h18] - [ RailNodeA][ RailNodeD] - [12.31km] - [Maintain] - [O][ ][ ][ ][ ][ ][ ][ ][ ][ ][ ][x][ ][ ][ ][ ][ ][ ]
[00h32] - [ RailNodeD][     CityB] - [00.53km] - [ Braking] - [ ][ ][ ][ ][ ][ ][x]

Actual travel time : 00h32m
```

## How to Test

```bash
make fclean && make all    # build (0 warnings)
make run                   # run with sample input — generates .result files
make test                  # run all 82 tests across 9 suites
./bin/Train --help         # show input format documentation
```

## Checklist

- [x] Compiles with `make CXX=g++` and `make CXX=clang++` (zero warnings)
- [x] All tests pass (`make test`) — 82/82
- [x] No memory leaks (valgrind clean)