### PR TITLE
docs: update README with physics sim, design patterns, diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Train Yourself — Rail Network Simulator
 
-A train simulation engine that models rail traffic across a configurable network of stations and tracks. Trains find optimal routes, travel in real time, and face random disruptions — producing a full arrival report with delays.
+A physics-based train simulation engine that models rail traffic across a configurable network of stations and tracks. Trains find optimal routes via Dijkstra, accelerate and brake according to real forces (F = ma with rolling friction), handle overtaking on shared segments, and produce per-train result files with every-minute snapshots.
 
-## Why It Matters
+> **42 OOP Piscine — Module 05**
 
-Rail logistics is a billion-euro industry where even small scheduling improvements save fuel, time, and money. This simulator lets you:
+## Features
 
-- **Model any rail network** — define stations, tracks, distances, and speed limits in a plain text file.
-- **Simulate realistic traffic** — multiple trains depart at different times, each finding the shortest route automatically.
-- **Inject random events** — disruptions like riots or passenger discomfort trigger probabilistically, causing delays at specific stations.
-- **Analyse results** — every train's journey is logged with departure, route, events, arrival time, and accumulated delay.
-
-It serves as both a learning tool for software engineering (OOP, design patterns, testing, CI) and a foundation that could be extended into a real planning aid.
+| Feature | Detail |
+|---------|--------|
+| **Physics engine** | 1-second discrete timestep · acceleration = `(F_accel − μmg) / m` · braking distance = `v² / (2·decel)` |
+| **Concurrent simulation** | All trains run on a shared wall clock; overtaking caps a trailing train's speed |
+| **Pathfinding** | Dijkstra shortest-path (Strategy pattern — swappable algorithm) |
+| **Per-train output** | `TrainName_HHhMM.result` file with header, estimated time, every-minute rail graph, events, actual time |
+| **Random events** | Probability-based disruptions at stations (riots, discomfort, …) inject delays |
+| **82 unit / integration tests** | Custom TestFramework, 9 suites, CI with gcc + clang matrix |
+| **3 design patterns** | Strategy (pathfinding), Factory (train creation), Observer (file output) |
+| **7 UML diagrams** | Class, 3 sequence, state machine, 2 activity — PlantUML sources + PNGs |
 
 ## Quick Start
 
@@ -23,20 +27,18 @@ It serves as both a learning tool for software engineering (OOP, design patterns
 ### Build & Run
 
 ```bash
-# Build the binary
-make
+make                # build
+make run            # run with sample data
+./bin/Train --help  # show input file format
 
-# Run with the provided sample data
-make run
-
-# Or run manually with your own files
+# Or supply your own files
 ./bin/Train path/to/network.txt path/to/trains.txt
 ```
 
 ### Run Tests
 
 ```bash
-make test
+make test     # 82 tests across 9 suites
 ```
 
 ### Clean
@@ -49,9 +51,11 @@ make re       # full rebuild
 
 ## Input Format
 
-The simulator reads two text files:
+The simulator reads two text files (pass `--help` for full details).
 
-**Network file** — defines stations, events, and rail connections:
+### Network file
+
+Defines stations, events, and rail connections:
 
 ```
 Node CityA
@@ -61,15 +65,69 @@ Event "Passenger's Discomfort" 0.2 30m CityB
 Rail CityA CityB 15.0 250.0
 ```
 
-Each `Rail` line specifies: `from`, `to`, `distance (km)`, `speed limit (km/h)`.
+Each `Rail` line: `from`, `to`, `distance (km)`, `speed limit (km/h)`.
 
-**Train file** — defines trains:
+### Train file
+
+Defines trains with physics properties:
 
 ```
-TrainAB1 1.87 1.4 CityA CityB 14h10
+TrainAB 80 0.05 356.0 30.0 CityA CityB 14h10 00h10
 ```
 
-Fields: `name`, `acceleration`, `braking force`, `departure station`, `arrival station`, `departure time`.
+| # | Field | Unit |
+|---|-------|------|
+| 1 | Name | — |
+| 2 | Weight | metric tons |
+| 3 | Friction coefficient | — |
+| 4 | Max acceleration force | kN |
+| 5 | Max brake force | kN |
+| 6 | Departure station | — |
+| 7 | Arrival station | — |
+| 8 | Departure time | `HHhMM` |
+| 9 | Stop duration at stations | `HHhMM` |
+
+## Output
+
+Each train produces a `.result` file:
+
+```
+Train : TrainAB
+Final travel time : 00h32m
+
+[00h00] - [    CityA][RailNodeA] - [53.00km] - [Speed up] - [x][ ][ ] ... [ ][ ]
+[00h01] - [    CityA][RailNodeA] - [51.20km] - [Speed up] - [x][ ][ ] ... [ ][ ]
+...
+[00h32] - [RailNodeC][    CityB] - [00.00km] - [ Stopped] - [ ][ ][ ][ ][x]
+
+Actual travel time : 00h32m
+```
+
+Rail graph: `[x]` = this train, `[O]` = blocking train, `[ ]` = empty (1 cell per km).
+
+## Architecture
+
+See [docs/TECHNICAL.md](docs/TECHNICAL.md) for the full breakdown.
+
+### Design Patterns
+
+- **Strategy** — `IPathfinding` → `DijkstraPathfinding` (swap algorithm without touching simulation)
+- **Factory** — `TrainFactory::createTrain()` validates all 9 fields before construction
+- **Observer** — `ISimulationObserver` → `FileOutputObserver` (decouple simulation from I/O)
+
+### Diagrams
+
+All diagrams live in `docs/diagrams/` (`.puml` sources + `.png` renders):
+
+| Diagram | Description |
+|---------|-------------|
+| Class diagram | Full project structure with all classes and relationships |
+| Sequence — Simulation run | Concurrent physics loop with observer notifications |
+| Sequence — Input parsing | 9-field parsing flow through InputHandler → TrainFactory |
+| Sequence — Pathfinding | Dijkstra algorithm interaction with RailNetwork graph |
+| State — Train lifecycle | Waiting → Running → Stopped / Delayed → Arrived |
+| Activity — Physics tick | Per-second brake / accelerate / maintain decision |
+| Activity — Simulation overview | End-to-end flow from file loading to result generation |
 
 ## Author
 


### PR DESCRIPTION
## Changes\n\nFull README rewrite to reflect the current architecture:\n\n- **Features table** — physics engine, concurrent sim, pathfinding, observer output, events, tests, patterns, diagrams\n- **Input format** — updated to 9-field train format (weight, friction, accel/brake forces, stop duration)\n- **Output section** — documents the per-train `.result` file format with rail graph\n- **Architecture section** — links to TECHNICAL.md, lists all 3 design patterns, references all 7 UML diagrams\n- **Quick start** — adds `--help` flag, `make test` shows count (82 tests, 9 suites)\n\n## Memory\n\nmacOS `leaks` tool: **0 leaks for 0 total leaked bytes** ✅