### PR TITLE
feat: Add GraphExporter and organize output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ objs/
 *.dSYM/
 .nfs*
 
-# Simulation result files
-*.result
+# Program output directory
+output/
 
 # macOS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ INC			= -I$(SRCDIR)/Edge \
 			  -I$(SRCDIR)/OutputManager \
 			  -I$(SRCDIR)/Simulation \
 			  -I$(SRCDIR)/ISimulationObserver \
-			  -I$(SRCDIR)/FileOutputObserver
+			  -I$(SRCDIR)/FileOutputObserver \
+			  -I$(SRCDIR)/GraphExporter
 
 # Source files
 SRCS		= $(SRCDIR)/main.cpp \
@@ -36,7 +37,8 @@ SRCS		= $(SRCDIR)/main.cpp \
 			  $(SRCDIR)/InputHandler/InputHandler.cpp \
 			  $(SRCDIR)/OutputManager/OutputManager.cpp \
 			  $(SRCDIR)/Simulation/Simulation.cpp \
-			  $(SRCDIR)/FileOutputObserver/FileOutputObserver.cpp
+			  $(SRCDIR)/FileOutputObserver/FileOutputObserver.cpp \
+			  $(SRCDIR)/GraphExporter/GraphExporter.cpp
 
 # Object files
 OBJS		= $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
@@ -58,6 +60,7 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.cpp
 
 clean:
 	rm -rf $(OBJDIR)
+	rm -rf output
 
 fclean: clean
 	rm -rf $(BINDIR)
@@ -146,8 +149,16 @@ $(BINDIR)/IntegrationTest: $(TESTDIR)/IntegrationTest.cpp $(LIB_OBJS)
 #                                   UTILITY                                    #
 # ============================================================================ #
 
-run: all
-	./$(BINDIR)/$(NAME) input/railNetworkPrintFolder/railNetworkPrintGood.txt \
-		input/trainPrintFolder/trainPrintGood.txt
+NETWORK	= input/railNetworkPrintFolder/railNetworkPrintGood.txt
+TRAINS	= input/trainPrintFolder/trainPrintGood.txt
 
-.PHONY: all clean fclean re test run
+run: all
+	./$(BINDIR)/$(NAME) $(NETWORK) $(TRAINS)
+
+run-time: all
+	./$(BINDIR)/$(NAME) $(NETWORK) $(TRAINS) --time
+
+run-graph: all
+	./$(BINDIR)/$(NAME) $(NETWORK) $(TRAINS) --graph network.dot
+
+.PHONY: all clean fclean re test run run-time run-graph

--- a/src/FileOutputObserver/FileOutputObserver.cpp
+++ b/src/FileOutputObserver/FileOutputObserver.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 09:57:55 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 15:35:20 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
+#include <sys/stat.h>
 
 /* ---- Static helpers ---- */
 std::string FileOutputObserver::fmtTimeShort(double seconds)
@@ -28,10 +29,18 @@ std::string FileOutputObserver::fmtTimeShort(double seconds)
 	return buf;
 }
 
+static void ensureDir(const std::string &path)
+{
+	mkdir(path.c_str(), 0755);
+}
+
 std::string FileOutputObserver::buildFilename(const std::string &trainName,
 											  double departureTimeSec)
 {
-	return trainName + "_" + fmtTimeShort(departureTimeSec) + ".result";
+	ensureDir("output");
+	ensureDir("output/results");
+	return "output/results/" + trainName + "_" + fmtTimeShort(departureTimeSec)
+		   + ".result";
 }
 
 std::string FileOutputObserver::padRight(const std::string &s,

--- a/src/GraphExporter/GraphExporter.cpp
+++ b/src/GraphExporter/GraphExporter.cpp
@@ -1,0 +1,172 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   GraphExporter.cpp                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
+/*   Updated: 2026/02/21 15:35:20 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "GraphExporter.hpp"
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_set>
+
+#include "Node.hpp"
+#include "RailNetwork.hpp"
+#include "Train.hpp"
+
+/* ---- colour palette (8 distinct colours for up to 8 trains) ---- */
+static const char *TRAIN_COLOURS[] = {
+	"#e6194b", // red
+	"#3cb44b", // green
+	"#4363d8", // blue
+	"#f58231", // orange
+	"#911eb4", // purple
+	"#42d4f4", // cyan
+	"#f032e6", // magenta
+	"#bfef45", // lime
+};
+static constexpr size_t NUM_COLOURS = sizeof(TRAIN_COLOURS) / sizeof(TRAIN_COLOURS[0]);
+
+/* ---- helpers ---- */
+
+/** Build a canonical key for an undirected edge (alphabetical order). */
+static std::string edgeKey(const std::string &a, const std::string &b)
+{
+	return (a < b) ? a + "|" + b : b + "|" + a;
+}
+
+/* ---- public ---- */
+void GraphExporter::exportDot(
+	const std::string &filename,
+	const RailNetwork &network,
+	const std::vector<std::unique_ptr<Train>> &trains)
+{
+	std::ofstream out(filename);
+	if (!out.is_open())
+		throw std::runtime_error("Cannot create graph file: " + filename);
+
+	out << "graph RailNetwork {\n";
+	out << "    rankdir=LR;\n";
+	out << "    bgcolor=\"#1e1e2e\";\n";
+	out << "    pad=0.5;\n";
+	out << "    nodesep=0.8;\n";
+	out << "    ranksep=1.2;\n";
+	out << "    fontname=\"Helvetica\";\n";
+	out << "    label=<<b>Rail Network — Train Paths</b>>;\n";
+	out << "    labelloc=t;\n";
+	out << "    fontsize=18;\n";
+	out << "    fontcolor=\"#cdd6f4\";\n\n";
+
+	/* Node styling */
+	out << "    node [\n";
+	out << "        shape=box, style=\"filled,rounded\",\n";
+	out << "        fillcolor=\"#313244\", fontcolor=\"#cdd6f4\",\n";
+	out << "        color=\"#585b70\", fontname=\"Helvetica\",\n";
+	out << "        fontsize=11, margin=\"0.15,0.08\"\n";
+	out << "    ];\n\n";
+
+	/* Default edge style */
+	out << "    edge [\n";
+	out << "        color=\"#585b70\", fontcolor=\"#a6adc8\",\n";
+	out << "        fontname=\"Helvetica\", fontsize=9\n";
+	out << "    ];\n\n";
+
+	/* Emit all nodes — highlight stations (City*) differently */
+	auto nodeNames = network.getNodeNames();
+	for (const auto &name : nodeNames)
+	{
+		bool isCity = (name.substr(0, 4) == "City");
+		if (isCity)
+			out << "    \"" << name
+				<< "\" [fillcolor=\"#89b4fa\", fontcolor=\"#1e1e2e\","
+				<< " style=\"filled,rounded,bold\", penwidth=2];\n";
+		else
+			out << "    \"" << name << "\";\n";
+	}
+	out << "\n";
+
+	/* Collect all edges (undirected — avoid duplicates) */
+	std::set<std::string> emitted;
+	for (const auto &nodeName : nodeNames)
+	{
+		for (const auto &edge : network.getNeighbours(nodeName))
+		{
+			const std::string &dest = edge.destination->getName();
+			std::string key = edgeKey(nodeName, dest);
+			if (emitted.count(key))
+				continue;
+			emitted.insert(key);
+
+			char label[64];
+			std::snprintf(label, sizeof(label), "%.1f km\\n%.0f km/h",
+						  edge.distance, edge.speedLimit);
+			out << "    \"" << nodeName << "\" -- \"" << dest
+				<< "\" [label=\"" << label << "\"];\n";
+		}
+	}
+	out << "\n";
+
+	/* Overlay each train's path in colour */
+	for (size_t t = 0; t < trains.size(); t++)
+	{
+		const auto &path = trains[t]->getPath();
+		if (path.size() < 2)
+			continue;
+
+		const char *colour = TRAIN_COLOURS[t % NUM_COLOURS];
+
+		/* Legend entry: invisible node + label */
+		out << "    \"_legend_" << t
+			<< "\" [label=\"" << trains[t]->getName()
+			<< "\", shape=plaintext, fontcolor=\"" << colour
+			<< "\", fontsize=12, fontname=\"Helvetica Bold\"];\n";
+
+		for (size_t i = 0; i + 1 < path.size(); i++)
+		{
+			const std::string &from = path[i]->getName();
+			const std::string &to = path[i + 1]->getName();
+
+			/* Look up the edge to annotate speed */
+			double speed = 0.0;
+			for (const auto &edge : network.getNeighbours(from))
+			{
+				if (edge.destination->getName() == to)
+				{
+					speed = edge.speedLimit;
+					break;
+				}
+			}
+
+			out << "    \"" << from << "\" -- \"" << to
+				<< "\" [color=\"" << colour
+				<< "\", penwidth=3, style=bold";
+			if (speed > 0.0)
+			{
+				char speedLabel[32];
+				std::snprintf(speedLabel, sizeof(speedLabel),
+							  "%.0f km/h", speed);
+				out << ", label=\"" << speedLabel << "\","
+					<< " fontcolor=\"" << colour << "\"";
+			}
+			out << "];\n";
+		}
+		out << "\n";
+	}
+
+	out << "}\n";
+	out.close();
+
+	std::cout << "Graph exported to " << filename << std::endl;
+	std::cout << "Render with: dot -Tpng " << filename
+			  << " -o output/graphs/network.png" << std::endl;
+}

--- a/src/GraphExporter/GraphExporter.hpp
+++ b/src/GraphExporter/GraphExporter.hpp
@@ -1,0 +1,42 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   GraphExporter.hpp                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
+/*   Updated: 2026/02/21 15:14:11 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef GRAPHEXPORTER_HPP
+#define GRAPHEXPORTER_HPP
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class RailNetwork;
+class Train;
+
+/**
+ * Generates a Graphviz DOT file that visualises the rail network
+ * with each train's computed path highlighted in a unique colour.
+ *
+ * Usage:
+ *   GraphExporter::exportDot("network.dot", network, trains);
+ *   // then: dot -Tpng network.dot -o network.png
+ */
+class GraphExporter
+{
+  public:
+	GraphExporter() = delete;
+
+	static void exportDot(
+		const std::string &filename,
+		const RailNetwork &network,
+		const std::vector<std::unique_ptr<Train>> &trains);
+};
+
+#endif

--- a/src/Simulation/Simulation.cpp
+++ b/src/Simulation/Simulation.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 14:26:44 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 15:23:38 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,14 @@ Simulation::Simulation(RailNetwork network,
 }
 
 Simulation::~Simulation() {}
+
+/* ---- Const accessors (for auxiliary tools) ---- */
+const RailNetwork &Simulation::getNetwork() const { return _network; }
+
+const std::vector<std::unique_ptr<Train>> &Simulation::getTrains() const
+{
+	return _trains;
+}
 
 /* ---- Public ---- */
 void Simulation::run()

--- a/src/Simulation/Simulation.hpp
+++ b/src/Simulation/Simulation.hpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 14:26:44 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 15:23:38 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,6 +67,9 @@ class Simulation
 	~Simulation();
 
 	void run();
+
+	const RailNetwork &getNetwork() const;
+	const std::vector<std::unique_ptr<Train>> &getTrains() const;
 
   private:
 	void computePaths();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 14:26:44 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 15:35:20 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,10 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <sys/stat.h>
 
 #include "DijkstraPathfinding.hpp"
+#include "GraphExporter.hpp"
 #include "IPathfinding.hpp"
 #include "InputHandler.hpp"
 #include "Simulation.hpp"
@@ -23,10 +25,12 @@
 static void printHelp()
 {
 	std::cout
-		<< "Usage: ./Train <network_file> <train_file> [--time]\n\n"
+		<< "Usage: ./Train <network_file> <train_file> [options]\n\n"
 		<< "Options:\n"
-		<< "  --time    Optimise route by travel time instead of "
-		<< "distance\n\n"
+		<< "  --time              Optimise route by travel time "
+		<< "instead of distance\n"
+		<< "  --graph <file.dot>  Export network + paths as "
+		<< "Graphviz DOT file (default: output/graphs/)\n\n"
 		<< "=== Network file format ===\n"
 		<< "  Node <name>\n"
 		<< "    Declares a station or junction in the network.\n\n"
@@ -52,8 +56,8 @@ static void printHelp()
 		<< "    stop_duration   - Duration of stop at each station "
 		<< "(e.g. 00h10)\n\n"
 		<< "=== Output ===\n"
-		<< "  The program generates one .result file per train:\n"
-		<< "    TrainName_DepartureTime.result\n";
+		<< "  The program generates one .result file per train in\n"
+		<< "    output/results/TrainName_DepartureTime.result\n";
 }
 
 int main(int argc, char **argv)
@@ -63,24 +67,35 @@ int main(int argc, char **argv)
 		printHelp();
 		return EXIT_SUCCESS;
 	}
-	if (argc < 3 || argc > 4)
+	if (argc < 3 || argc > 6)
 	{
 		std::cerr << "Usage: " << argv[0]
-				  << " <network_file> <train_file> [--time]" << std::endl;
+				  << " <network_file> <train_file> [--time] "
+				     "[--graph file.dot]" << std::endl;
 		std::cerr << "Use --help for detailed format information."
 				  << std::endl;
 		return EXIT_FAILURE;
 	}
 
-	/* Parse optional --time flag */
+	/* Parse optional flags */
 	PathWeightMode weightMode = PathWeightMode::Distance;
-	if (argc == 4)
+	std::string graphFile;
+	for (int i = 3; i < argc; i++)
 	{
-		if (std::strcmp(argv[3], "--time") == 0)
+		if (std::strcmp(argv[i], "--time") == 0)
 			weightMode = PathWeightMode::Time;
+		else if (std::strcmp(argv[i], "--graph") == 0)
+		{
+			if (i + 1 >= argc)
+			{
+				std::cerr << "--graph requires a filename" << std::endl;
+				return EXIT_FAILURE;
+			}
+			graphFile = argv[++i];
+		}
 		else
 		{
-			std::cerr << "Unknown option: " << argv[3] << std::endl;
+			std::cerr << "Unknown option: " << argv[i] << std::endl;
 			return EXIT_FAILURE;
 		}
 	}
@@ -94,6 +109,18 @@ int main(int argc, char **argv)
 					   std::move(data.events), std::move(pathfinder),
 					   weightMode);
 		sim.run();
+
+		/* Export graph after simulation (standalone utility) */
+		if (!graphFile.empty())
+		{
+			mkdir("output", 0755);
+			mkdir("output/graphs", 0755);
+			/* Prepend output dir if user gave a bare filename */
+			if (graphFile.find('/') == std::string::npos)
+				graphFile = "output/graphs/" + graphFile;
+			GraphExporter::exportDot(graphFile, sim.getNetwork(),
+									 sim.getTrains());
+		}
 	}
 	catch (const std::exception &e)
 	{

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/21 10:02:58 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/21 15:35:20 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,9 +22,9 @@
 
 static void cleanupResults()
 {
-	std::remove("TrainAB_14h10.result");
-	std::remove("TrainAC_14h20.result");
-	std::remove("TrainBA_14h24.result");
+	std::remove("output/results/TrainAB_14h10.result");
+	std::remove("output/results/TrainAC_14h20.result");
+	std::remove("output/results/TrainBA_14h24.result");
 }
 
 int main()
@@ -149,11 +149,11 @@ int main()
 					  std::move(data.events),
 					  std::make_unique<DijkstraPathfinding>());
 				  sim.run();
-				  std::ifstream f1("TrainAB_14h10.result");
+				  std::ifstream f1("output/results/TrainAB_14h10.result");
 				  ASSERT_TRUE(f1.is_open(), msg);
-				  std::ifstream f2("TrainAC_14h20.result");
+				  std::ifstream f2("output/results/TrainAC_14h20.result");
 				  ASSERT_TRUE(f2.is_open(), msg);
-				  std::ifstream f3("TrainBA_14h24.result");
+				  std::ifstream f3("output/results/TrainBA_14h24.result");
 				  ASSERT_TRUE(f3.is_open(), msg);
 				  return true;
 			  });
@@ -170,7 +170,7 @@ int main()
 					  std::move(data.events),
 					  std::make_unique<DijkstraPathfinding>());
 				  sim.run();
-				  std::ifstream f("TrainAB_14h10.result");
+				  std::ifstream f("output/results/TrainAB_14h10.result");
 				  std::string line;
 				  std::getline(f, line);
 				  ASSERT_TRUE(line.find("TrainAB") != std::string::npos,


### PR DESCRIPTION
## Description\n\nAdds a **GraphExporter** utility that generates Graphviz DOT files to visualize the rail network with each train's computed path highlighted in a unique colour. Also reorganizes all program outputs into a structured `output/` directory.\n\n### Changes\n- **GraphExporter** (`src/GraphExporter/`) — standalone static class that exports network + train paths as DOT with dark Catppuccin theme, colour-coded paths, edge labels (distance + speed), and a legend\n- **Output directory structure** — all generated files now go to:\n  - `output/results/` — per-train `.result` files\n  - `output/graphs/` — `.dot` files (and rendered `.png`/`.svg`)\n- **CLI flag** `--graph <file.dot>` — bare filenames auto-prefixed to `output/graphs/`\n- **Simulation decoupling** — GraphExporter called only from `main.cpp` via new `getNetwork()` / `getTrains()` const accessors\n- **Makefile targets** — `make run`, `make run-time`, `make run-graph`; `clean` removes `output/`\n- **Updated** `.gitignore`, `IntegrationTest.cpp` paths, help text\n\n## Screenshots\n\n```bash\n$ make run-graph\n...\nGraph exported to output/graphs/network.dot\nRender with: dot -Tpng output/graphs/network.dot -o output/graphs/network.png\n\n$ tree output/\noutput/\n├── graphs/\n│   └── network.dot\n└── results/\n    ├── TrainAB_14h10.result\n    ├── TrainAC_14h20.result\n    └── TrainBA_14h24.result\n```\n\n## How to Test\n\n```bash\nmake fclean && make all    # build\nmake run                   # run (distance mode)\nmake run-time              # run (time mode)\nmake run-graph             # run + export graph\nmake test                  # run all test suites (86 tests)\nmake clean                 # verify output/ is removed\n```\n\n## Checklist\n\n- [x] Compiles with `make CXX=g++` and `make CXX=clang++` (zero warnings)\n- [x] All tests pass (`make test`) — 86/86\n- [x] No memory leaks (valgrind clean)"