### PR TITLE
fix(gui): use-after-free crash in NetworkScene::clearTrains()

### DIFF
--- a/bonus/gui/NetworkScene.cpp
+++ b/bonus/gui/NetworkScene.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   NetworkScene.cpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 10:21:12 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/23 14:04:59 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -253,6 +253,7 @@ void NetworkScene::clear()
 	_nodes.clear();
 	_edges.clear();
 	_trains.clear();
+	_trailLines.clear();
 }
 
 /* ================================================================== */
@@ -487,15 +488,18 @@ void NetworkScene::clearTrains()
 {
 	for (auto *seg : _trailLines)
 	{
-		removeItem(seg);
+		if (seg->scene() == this)
+			removeItem(seg);
 		delete seg;
 	}
 	_trailLines.clear();
 
 	for (auto it = _trains.begin(); it != _trains.end(); ++it)
 	{
-		removeItem(it.value().dot);
-		removeItem(it.value().label);
+		if (it.value().dot->scene() == this)
+			removeItem(it.value().dot);
+		if (it.value().label->scene() == this)
+			removeItem(it.value().label);
 		delete it.value().dot;
 		delete it.value().label;
 	}


### PR DESCRIPTION
## Description

Fixes a SIGSEGV crash (`EXC_BAD_ACCESS` at `KERN_INVALID_ADDRESS 0x4f9be6`) triggered when running a simulation after loading a new network.

## Root Cause

`NetworkScene::clear()` calls `QGraphicsScene::clear()` which **frees all graphics items** in the scene, then clears `_nodes`, `_edges`, and `_trains` — but **not `_trailLines`**. The trail line pointers become dangling.

When the user subsequently runs a simulation, `onRunSimulation()` calls `clearTrains()`, which iterates `_trailLines` and calls `removeItem()` on already-freed memory → `QGraphicsItem::scene()` dereferences garbage → **SIGSEGV**.

### Crash path
1. Load network → run simulation (populates `_trailLines`)
2. Load new network → `clear()` frees all items but forgets `_trailLines`
3. Run simulation again → `clearTrains()` → use-after-free

## Changes

| File | Change |
|------|--------|
| `bonus/gui/NetworkScene.cpp` | Add `_trailLines.clear()` to `clear()` |
| `bonus/gui/NetworkScene.cpp` | Add `scene() == this` guards in `clearTrains()` before `removeItem()` calls |

## Crash Report (key frames)

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0  QtWidgets  QGraphicsItem::scene() const + 4
1  QtWidgets  QGraphicsScene::removeItem(QGraphicsItem*) + 64
2  TrainGUI   NetworkScene::clearTrains() + 192
3  TrainGUI   MainWindow::onRunSimulation() + 2936
```

## Testing

- [x] `make bonus` builds clean (no warnings)
- [x] Verified trail lines are properly cleaned up when loading a new network
- [x] Re-running simulations no longer crashes