### PR TITLE
fix(gui): smooth dashboard progress bars

### DIFF
--- a/bonus/gui/SimDashboard.cpp
+++ b/bonus/gui/SimDashboard.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   SimDashboard.cpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/23 01:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:06:28 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/23 23:25:46 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -286,9 +286,13 @@ void SimDashboard::update(double simTime,
 			if (s.pathSize > 1)
 			{
 				double segCount = static_cast<double>(s.pathSize - 1);
-				frac = static_cast<double>(s.segmentIndex) / segCount;
-				if (s.segmentIndex + 1 < s.pathSize)
-					frac += (1.0 / segCount) * 0.5;
+				double withinSeg = 0.0;
+				if (s.segmentLength_m > 0.0)
+					withinSeg = s.posOnSegment_m / s.segmentLength_m;
+				if (withinSeg < 0.0) withinSeg = 0.0;
+				if (withinSeg > 1.0) withinSeg = 1.0;
+				frac = (static_cast<double>(s.segmentIndex) + withinSeg)
+					   / segCount;
 				if (frac > 1.0)
 					frac = 1.0;
 			}

--- a/bonus/gui/SimulationWorker.cpp
+++ b/bonus/gui/SimulationWorker.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   SimulationWorker.cpp                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:06:28 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/23 23:25:46 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,7 +95,7 @@ void SimulationWorker::runSimulation(const QString &networkFile,
 		double lastEmit = -BASE_INTERVAL;
 
 		sim.setAnimCallback(
-			[this, &lastEmit](double simTime,
+			[this, &lastEmit, &sim](double simTime,
 				   const std::vector<TrainState> &states) {
 				if (_stopRequested.load(std::memory_order_relaxed))
 					throw SimulationStopException();
@@ -136,6 +136,24 @@ void SimulationWorker::runSimulation(const QString &networkFile,
 					snap.arrived = s.arrived;
 					snap.segmentIndex = s.segmentIndex;
 					snap.pathSize = path.size();
+					snap.segmentLength_m = 0.0;
+					if (path.size() >= 2
+						&& s.segmentIndex + 1 < path.size())
+					{
+						try {
+							const auto &edges = sim.getNetwork()
+								.getNeighbours(path[s.segmentIndex]->getName());
+							for (const auto &e : edges)
+							{
+								if (e.destination->getName()
+									== path[s.segmentIndex + 1]->getName())
+								{
+									snap.segmentLength_m = e.distance * 1000.0;
+									break;
+								}
+							}
+						} catch (...) {}
+					}
 					snaps.push_back(snap);
 				}
 				emit tick(simTime, snaps);
@@ -225,7 +243,7 @@ void SimulationWorker::runMulti(const QString &networkFile,
 				double lastEmit = -BASE_INTERVAL;
 
 				sim.setAnimCallback(
-					[this, &lastEmit](double simTime,
+					[this, &lastEmit, &sim](double simTime,
 									  const std::vector<TrainState> &states) {
 						if (_stopRequested.load(std::memory_order_relaxed))
 							throw SimulationStopException();
@@ -265,6 +283,24 @@ void SimulationWorker::runMulti(const QString &networkFile,
 							snap.arrived = s.arrived;
 							snap.segmentIndex = s.segmentIndex;
 							snap.pathSize = path.size();
+							snap.segmentLength_m = 0.0;
+							if (path.size() >= 2
+								&& s.segmentIndex + 1 < path.size())
+							{
+								try {
+									const auto &edges = sim.getNetwork()
+										.getNeighbours(path[s.segmentIndex]->getName());
+									for (const auto &e : edges)
+									{
+										if (e.destination->getName()
+											== path[s.segmentIndex + 1]->getName())
+										{
+											snap.segmentLength_m = e.distance * 1000.0;
+											break;
+										}
+									}
+								} catch (...) {}
+							}
 							snaps.push_back(snap);
 						}
 						emit tick(simTime, snaps);

--- a/bonus/gui/SimulationWorker.hpp
+++ b/bonus/gui/SimulationWorker.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   SimulationWorker.hpp                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:06:28 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/23 23:25:46 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,7 @@ struct TrainSnapshot
 	bool arrived;
 	size_t segmentIndex;
 	size_t pathSize;
+	double segmentLength_m;
 };
 
 Q_DECLARE_METATYPE(QVector<TrainSnapshot>)


### PR DESCRIPTION
## Description\n\nFix the GUI dashboard progress bars that were not moving smoothly during simulation.\n\n## Problem\n\nThe progress bars in the `SimDashboard` were jumping discretely between segments instead of animating smoothly. The fraction was calculated using only `segmentIndex` (which segment the train is on), completely ignoring `posOnSegment_m` (the train's position within the current segment).\n\n## Solution\n\n- Added `segmentLength_m` field to `TrainSnapshot` so the dashboard knows the total length of the current segment\n- In `SimulationWorker`, both single-run and multi-run animation callbacks now look up the edge distance from the network and populate `segmentLength_m`\n- Updated `SimDashboard::update()` to compute a smooth fraction:\n  ```\n  fraction = (segmentIndex + posOnSegment_m / segmentLength_m) / totalSegments\n  ```\n  instead of the previous discrete approximation\n\n## Files Changed\n\n| File | Change |\n|------|--------|\n| `bonus/gui/SimulationWorker.hpp` | Added `segmentLength_m` to `TrainSnapshot` |\n| `bonus/gui/SimulationWorker.cpp` | Populate `segmentLength_m` from network edge data (both callbacks) |\n| `bonus/gui/SimDashboard.cpp` | Smooth progress bar fraction calculation |\n\n## Testing\n\n- [x] `make bonus` builds successfully\n- [x] `make test` — all 26 tests pass\n- [x] No regressions in existing functionality"