### PR TITLE
fix: WSL/Linux compatibility for bonus GUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,12 +210,13 @@ deps-gui:
 #                                   BONUS                                      #
 # ============================================================================ #
 
-# Auto-detect qmake: try qmake6, qmake, then common Homebrew paths
+# Auto-detect qmake: try qmake6, qmake, then common Homebrew/Linux paths
 QMAKE := $(shell command -v qmake6 2>/dev/null \
          || command -v qmake 2>/dev/null \
          || ([ -x /opt/homebrew/bin/qmake ] && echo /opt/homebrew/bin/qmake) \
          || ([ -x /opt/homebrew/opt/qt/bin/qmake ] && echo /opt/homebrew/opt/qt/bin/qmake) \
          || ([ -x /usr/local/bin/qmake ] && echo /usr/local/bin/qmake) \
+         || ([ -x /usr/lib/qt6/bin/qmake ] && echo /usr/lib/qt6/bin/qmake) \
          || echo "")
 
 bonus:
@@ -227,13 +228,14 @@ bonus:
 	fi
 	@echo "\nBuilding Qt GUI bonus..."
 	@mkdir -p objs/gui/moc
-	@cd bonus/gui && $(QMAKE) bonus.pro && $(MAKE) -j4
+	@cd bonus/gui && rm -f .qmake.stash && $(QMAKE) bonus.pro && $(MAKE) -j4
 	@echo "\nTrainGUI built successfully ✓  →  bin/TrainGUI\n"
 
 bonus-clean:
 	@cd bonus/gui && [ -f Makefile ] && $(MAKE) clean || true
 	rm -rf objs/gui
 	rm -f $(BINDIR)/TrainGUI
+	rm -rf $(BINDIR)/TrainGUI.app
 
 run-animate: all
 	./$(BINDIR)/$(NAME) $(NETWORK) $(TRAINS) --animate

--- a/bonus/gui/MainWindow.cpp
+++ b/bonus/gui/MainWindow.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   MainWindow.cpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:06:28 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/02/24 00:09:19 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,17 @@
 #include <QDateTime>
 #include <QDir>
 #include <cmath>
+
+/*  Qt 6.3 added  addAction(text, shortcut, receiver, slot).
+    Qt 6.2 only has addAction(text, receiver, slot, shortcut).
+    Use this macro so the code compiles on both without deprecation warnings. */
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+# define MENU_ACTION(menu, text, shortcut, rcv, slot) \
+    (menu)->addAction((text), QKeySequence(shortcut), (rcv), (slot))
+#else
+# define MENU_ACTION(menu, text, shortcut, rcv, slot) \
+    (menu)->addAction((text), (rcv), (slot), QKeySequence(shortcut))
+#endif
 #include <QDockWidget>
 #include <QDoubleSpinBox>
 #include <QFileDialog>
@@ -338,23 +349,23 @@ bool MainWindow::guardSimRunning(const QString &action)
 void MainWindow::buildMenus()
 {
 	QMenu *file = menuBar()->addMenu("&File");
-	file->addAction("Import All...", QKeySequence("Ctrl+I"),
-					this, &MainWindow::onImportAll);
+	MENU_ACTION(file, "Import All...", "Ctrl+I",
+				this, &MainWindow::onImportAll);
 	file->addSeparator();
-	file->addAction("Load Network...", QKeySequence("Ctrl+O"),
-					this, &MainWindow::onLoadNetwork);
-	file->addAction("Load Trains...", QKeySequence("Ctrl+T"),
-					this, &MainWindow::onLoadTrains);
+	MENU_ACTION(file, "Load Network...", "Ctrl+O",
+				this, &MainWindow::onLoadNetwork);
+	MENU_ACTION(file, "Load Trains...", "Ctrl+T",
+				this, &MainWindow::onLoadTrains);
 	file->addSeparator();
 	file->addAction("Save Network...", this, &MainWindow::onSaveNetwork);
 	file->addAction("Save Trains...", this, &MainWindow::onSaveTrains);
 	file->addSeparator();
-	file->addAction("Export All...", QKeySequence("Ctrl+E"),
-					this, &MainWindow::onExportAll);
-	file->addAction("Export as DOT...", QKeySequence("Ctrl+G"),
-					this, &MainWindow::onExportDot);
+	MENU_ACTION(file, "Export All...", "Ctrl+E",
+				this, &MainWindow::onExportAll);
+	MENU_ACTION(file, "Export as DOT...", "Ctrl+G",
+				this, &MainWindow::onExportDot);
 	file->addSeparator();
-	file->addAction("Quit", QKeySequence("Ctrl+Q"), this, &QWidget::close);
+	MENU_ACTION(file, "Quit", "Ctrl+Q", this, &QWidget::close);
 
 	QMenu *edit = menuBar()->addMenu("&Edit");
 	edit->addAction("Add Node...", this, &MainWindow::onAddNode);
@@ -373,12 +384,12 @@ void MainWindow::buildMenus()
 	edit->addAction("Delete Selected Event", this, &MainWindow::onDeleteEvent);
 
 	QMenu *sim = menuBar()->addMenu("&Simulation");
-	sim->addAction("Run", QKeySequence("Ctrl+R"),
-				   this, &MainWindow::onRunSimulation);
+	MENU_ACTION(sim, "Run", "Ctrl+R",
+				this, &MainWindow::onRunSimulation);
 
 	QMenu *help = menuBar()->addMenu("&Help");
-	help->addAction("Controls && Shortcuts...", QKeySequence("F1"),
-					this, [this]() {
+	MENU_ACTION(help, "Controls && Shortcuts...", "F1",
+				this, [this]() {
 		QMessageBox box(this);
 		box.setWindowTitle("Controls & Shortcuts");
 		box.setIcon(QMessageBox::Information);
@@ -690,9 +701,11 @@ void MainWindow::scanPresetFiles()
 	   scanning works regardless of how the app was launched (open,
 	   double-click, terminal, etc.). */
 	QDir root(QCoreApplication::applicationDirPath());
+#ifdef Q_OS_MACOS
 	root.cdUp(); // MacOS -> Contents
 	root.cdUp(); // Contents -> TrainGUI.app
 	root.cdUp(); // TrainGUI.app -> bin
+#endif
 	root.cdUp(); // bin -> project root
 
 	/* Scan network presets (skip files with known-bad names) */

--- a/bonus/gui/SimulationWorker.cpp
+++ b/bonus/gui/SimulationWorker.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 23:25:46 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/02/24 00:09:19 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,9 +68,11 @@ void SimulationWorker::runSimulation(const QString &networkFile,
 		   write to the relative "output/results/" directory.
 		   QFileDialog may have changed the CWD in the main thread. */
 		QDir projectRoot(QCoreApplication::applicationDirPath());
+#ifdef Q_OS_MACOS
 		projectRoot.cdUp(); // MacOS -> Contents
 		projectRoot.cdUp(); // Contents -> TrainGUI.app
 		projectRoot.cdUp(); // TrainGUI.app -> bin
+#endif
 		projectRoot.cdUp(); // bin -> project root
 		QDir::setCurrent(projectRoot.absolutePath());
 		QDir().mkpath("output/results");
@@ -203,9 +205,11 @@ void SimulationWorker::runMulti(const QString &networkFile,
 	{
 		/* Ensure CWD is the project root */
 		QDir projectRoot(QCoreApplication::applicationDirPath());
+#ifdef Q_OS_MACOS
 		projectRoot.cdUp();
 		projectRoot.cdUp();
 		projectRoot.cdUp();
+#endif
 		projectRoot.cdUp();
 		QDir::setCurrent(projectRoot.absolutePath());
 		QDir().mkpath("output/results");

--- a/bonus/gui/bonus.pro
+++ b/bonus/gui/bonus.pro
@@ -53,3 +53,8 @@ HEADERS += \
 
 OBJECTS_DIR = ../../objs/gui
 MOC_DIR     = ../../objs/gui/moc
+
+# On Linux the binary goes straight into DESTDIR (no .app bundle)
+linux {
+    CONFIG -= app_bundle
+}


### PR DESCRIPTION
## Description\nFixes cross-platform compilation failures when building the bonus GUI on WSL (Ubuntu 22.04) and native Linux. The bonus previously only compiled on macOS.\n\n## Problem\nThe bonus GUI failed to compile on WSL/Linux due to:\n1. **Qt 6.2 API incompatibility** — `QMenu::addAction(text, QKeySequence, receiver, slot)` requires Qt 6.3+. Ubuntu 22.04 ships Qt 6.2.4.\n2. **macOS `.app` bundle path assumptions** — `cdUp()` calls assumed the binary lives inside `bin/TrainGUI.app/Contents/MacOS/`, but on Linux it's flat at `bin/TrainGUI`.\n3. **qmake project file** — No Linux platform handling; tried to create `.app` bundle on Linux.\n4. **Makefile** — qmake detection missed common Linux paths; stale `.qmake.stash` from macOS caused cross-platform build failures.\n\n## Solution\n\n### `bonus/gui/MainWindow.cpp`\n- Added `MENU_ACTION` version-conditional macro that selects the correct `addAction()` parameter order based on `QT_VERSION`:\n  - Qt >= 6.3: `addAction(text, shortcut, receiver, slot)` (new API)\n  - Qt < 6.3: `addAction(text, receiver, slot, shortcut)` (Qt 6.2 API)\n- Replaced all 8 `addAction()` calls with keyboard shortcuts to use the macro\n- Added `#ifdef Q_OS_MACOS` guard around extra `cdUp()` calls in `scanPresetFiles()`\n\n### `bonus/gui/SimulationWorker.cpp`\n- Added `#ifdef Q_OS_MACOS` guards around extra `cdUp()` calls in both `runSimulation()` and `runMulti()` (macOS needs 4 cdUp for `.app` bundle, Linux needs 1)\n\n### `bonus/gui/bonus.pro`\n- Added `linux { CONFIG -= app_bundle }` so Linux outputs a flat binary\n\n### `Makefile`\n- Added `/usr/lib/qt6/bin/qmake` to Linux qmake detection\n- Added `rm -f .qmake.stash` before qmake to prevent stale cross-platform cache issues\n- Added `.app` directory cleanup to `bonus-clean` target\n\n## Testing\n- [x] macOS: `make re` — builds successfully\n- [x] macOS: `make test` — 26/26 tests pass\n- [x] macOS: `make bonus` — GUI builds with zero warnings/errors\n- [ ] WSL/Linux: Pending verification by collaborator\n\n## Files Changed\n| File | Changes |\n|------|--------|\n| `bonus/gui/MainWindow.cpp` | MENU_ACTION macro + Q_OS_MACOS cdUp guard |\n| `bonus/gui/SimulationWorker.cpp` | Q_OS_MACOS cdUp guards (2 locations) |\n| `bonus/gui/bonus.pro` | Linux app_bundle disable |\n| `Makefile` | Linux qmake path + .qmake.stash cleanup |