### PR TITLE
feat: rename binary, add graphviz deps, path weight toggle, cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ clang make
 
-    - name: Build with ${{ matrix.compiler }}
-      run: make CXX=${{ matrix.compiler }}
+    - name: Build with ${{ matrix.compiler }} (ASan enabled)
+      run: make CXX=${{ matrix.compiler }} SANITIZE=1
 
     - name: Run tests
-      run: make CXX=${{ matrix.compiler }} test
+      run: make CXX=${{ matrix.compiler }} SANITIZE=1 test
 
     - name: Smoke-run binary
       run: |
@@ -38,20 +38,6 @@ jobs:
 
     - name: Verify clean/fclean/re
       run: make CXX=${{ matrix.compiler }} clean && make CXX=${{ matrix.compiler }} fclean && make CXX=${{ matrix.compiler }} re
-
-  # ── Memory safety: AddressSanitizer ────────────────────────────────────
-  sanitize:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ make
-
-    - name: Build + test with ASan
-      run: make CXX=g++ SANITIZE=1 && make CXX=g++ SANITIZE=1 test
 
   # ── GUI: Qt bonus builds ───────────────────────────────────────────────
   bonus:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,84 +11,71 @@ on:
       - master
 
 jobs:
-  build:
+  # ── Build & test ─────────────────────────────────────────────────────────
+  build-test:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        compiler: [gcc, clang]
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up C++ environment
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y valgrind
-        if [ "${{ matrix.compiler }}" == 'gcc' ]; then
-          sudo apt-get install -y g++
-        elif [ "${{ matrix.compiler }}" == 'clang' ]; then
-          sudo apt-get install -y clang
-        fi
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ make valgrind
 
     - name: Build
-      run: |
-        if [ "${{ matrix.compiler }}" == 'gcc' ]; then
-          make CXX=g++
-        elif [ "${{ matrix.compiler }}" == 'clang' ]; then
-          make CXX=clang++
-        fi
+      run: make CXX=g++
+
+    - name: Run tests
+      run: make CXX=g++ test
+
+  # ── AddressSanitizer ────────────────────────────────────────────────────
+  sanitize:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ make
+
+    - name: Build + test with ASan
+      run: make CXX=g++ SANITIZE=1 && make CXX=g++ SANITIZE=1 test
+
+  # ── Multi-compiler (gcc + clang) ───────────────────────────────────────
+  multicompiler:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [g++, clang++]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ clang make
+
+    - name: Build with ${{ matrix.compiler }}
+      run: make CXX=${{ matrix.compiler }}
 
     - name: Run main program
       run: |
-        ./bin/Train input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt
-        ./bin/Train input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --time
-        ./bin/Train input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --graph output/graphs/ci_test.dot
-
-    - name: Run tests
-      run: |
-        if [ "${{ matrix.compiler }}" == 'gcc' ]; then
-          make CXX=g++ test
-        elif [ "${{ matrix.compiler }}" == 'clang' ]; then
-          make CXX=clang++ test
-        fi
-
-    - name: Valgrind - tests
-      run: |
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/NodeTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/RailNetworkTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/TrainTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/EventTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/DijkstraTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/InputHandlerTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/TrainFactoryTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/OutputManagerTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/IntegrationTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/EdgeCaseTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/CombinationTest
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/EndToEndTest
-
-    - name: Valgrind - main program (default mode)
-      run: |
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/Train input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt
-
-    - name: Valgrind - main program (--time mode)
-      run: |
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/Train input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --time
-
-    - name: Valgrind - main program (--graph mode)
-      run: |
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/Train input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --graph output/graphs/ci_test.dot
-
-    - name: Valgrind - main program (--runs mode)
-      run: |
-        valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./bin/Train input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --runs 3
+        ./bin/train_yourself input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt
+        ./bin/train_yourself input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --time
+        ./bin/train_yourself input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --graph output/graphs/ci_test.dot
 
     - name: Test clean/fclean/re targets
-      run: |
-        if [ "${{ matrix.compiler }}" == 'gcc' ]; then
-          make CXX=g++ clean && make CXX=g++ fclean && make CXX=g++ re
-        elif [ "${{ matrix.compiler }}" == 'clang' ]; then
-          make CXX=clang++ clean && make CXX=clang++ fclean && make CXX=clang++ re
-        fi
+      run: make CXX=${{ matrix.compiler }} clean && make CXX=${{ matrix.compiler }} fclean && make CXX=${{ matrix.compiler }} re
+
+  # ── Bonus GUI build ────────────────────────────────────────────────────
+  bonus:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ make qt6-base-dev libgl1-mesa-dev
+
+    - name: Build CLI + Qt GUI bonus
+      run: make CXX=g++ && make bonus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,38 +11,8 @@ on:
       - master
 
 jobs:
-  # ── Build & test ─────────────────────────────────────────────────────────
-  build-test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ make valgrind
-
-    - name: Build
-      run: make CXX=g++
-
-    - name: Run tests
-      run: make CXX=g++ test
-
-  # ── AddressSanitizer ────────────────────────────────────────────────────
-  sanitize:
-    runs-on: ubuntu-latest
-    needs: build-test
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ make
-
-    - name: Build + test with ASan
-      run: make CXX=g++ SANITIZE=1 && make CXX=g++ SANITIZE=1 test
-
-  # ── Multi-compiler (gcc + clang) ───────────────────────────────────────
-  multicompiler:
+  # ── Correctness: compile + test with g++ and clang++ ───────────────────
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -57,19 +27,36 @@ jobs:
     - name: Build with ${{ matrix.compiler }}
       run: make CXX=${{ matrix.compiler }}
 
-    - name: Run main program
+    - name: Run tests
+      run: make CXX=${{ matrix.compiler }} test
+
+    - name: Smoke-run binary
       run: |
         ./bin/train_yourself input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt
         ./bin/train_yourself input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --time
         ./bin/train_yourself input/railNetworkPrintFolder/railNetworkPrintGood.txt input/trainPrintFolder/trainPrintGood.txt --graph output/graphs/ci_test.dot
 
-    - name: Test clean/fclean/re targets
+    - name: Verify clean/fclean/re
       run: make CXX=${{ matrix.compiler }} clean && make CXX=${{ matrix.compiler }} fclean && make CXX=${{ matrix.compiler }} re
 
-  # ── Bonus GUI build ────────────────────────────────────────────────────
+  # ── Memory safety: AddressSanitizer ────────────────────────────────────
+  sanitize:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y build-essential g++ make
+
+    - name: Build + test with ASan
+      run: make CXX=g++ SANITIZE=1 && make CXX=g++ SANITIZE=1 test
+
+  # ── GUI: Qt bonus builds ───────────────────────────────────────────────
   bonus:
     runs-on: ubuntu-latest
-    needs: build-test
+    needs: test
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,29 @@
-NAME		= Train
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    Makefile                                           :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2026/02/28 20:50:03 by ctw03933          #+#    #+#              #
+#    Updated: 2026/03/01 15:45:29 by ctw03933         ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
+NAME		= train_yourself
 
 # Compiler
 CXX			= c++
-CXXFLAGS	= -Wall -Wextra -Werror -std=c++17 -g -MMD -MP
+CXXFLAGS	= -Wall -Wextra -Werror -Wshadow -std=c++17 -g -MMD -MP
+
+# Sanitizer flags — always enabled for tests, never for the main binary
+SANFLAGS	= -fsanitize=address -fno-omit-frame-pointer
+
+# make SANITIZE=1 → enable sanitizer on the main binary too (for CI leak checks)
+ifeq ($(SANITIZE),1)
+CXXFLAGS	+= -fsanitize=address -fno-omit-frame-pointer
+LDFLAGS		+= -fsanitize=address
+endif
 
 # Directories
 SRCDIR		= src
@@ -44,10 +65,34 @@ SRCS		= $(SRCDIR)/main.cpp \
 			  $(SRCDIR)/TerminalAnimDisplay/TerminalAnimDisplay.cpp
 
 # Object files
-OBJS		= $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
+OBJS		= $(OBJDIR)/main.o \
+			  $(OBJDIR)/Node/Node.o \
+			  $(OBJDIR)/RailNetwork/RailNetwork.o \
+			  $(OBJDIR)/Train/Train.o \
+			  $(OBJDIR)/Event/Event.o \
+			  $(OBJDIR)/TrainFactory/TrainFactory.o \
+			  $(OBJDIR)/DijkstraPathfinding/DijkstraPathfinding.o \
+			  $(OBJDIR)/InputHandler/InputHandler.o \
+			  $(OBJDIR)/OutputManager/OutputManager.o \
+			  $(OBJDIR)/Simulation/Simulation.o \
+			  $(OBJDIR)/FileOutputObserver/FileOutputObserver.o \
+			  $(OBJDIR)/GraphExporter/GraphExporter.o \
+			  $(OBJDIR)/TerminalAnimDisplay/TerminalAnimDisplay.o
 
 # Auto-generated header dependencies
-DEPS		= $(OBJS:.o=.d)
+DEPS		= $(OBJDIR)/main.d \
+			  $(OBJDIR)/Node/Node.d \
+			  $(OBJDIR)/RailNetwork/RailNetwork.d \
+			  $(OBJDIR)/Train/Train.d \
+			  $(OBJDIR)/Event/Event.d \
+			  $(OBJDIR)/TrainFactory/TrainFactory.d \
+			  $(OBJDIR)/DijkstraPathfinding/DijkstraPathfinding.d \
+			  $(OBJDIR)/InputHandler/InputHandler.d \
+			  $(OBJDIR)/OutputManager/OutputManager.d \
+			  $(OBJDIR)/Simulation/Simulation.d \
+			  $(OBJDIR)/FileOutputObserver/FileOutputObserver.d \
+			  $(OBJDIR)/GraphExporter/GraphExporter.d \
+			  $(OBJDIR)/TerminalAnimDisplay/TerminalAnimDisplay.d
 -include $(DEPS)
 
 # ============================================================================ #
@@ -61,7 +106,55 @@ $(BINDIR)/$(NAME): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $@
 	@echo "\n$(NAME) built successfully ✓\n"
 
-$(OBJDIR)/%.o: $(SRCDIR)/%.cpp
+$(OBJDIR)/main.o: $(SRCDIR)/main.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/Node/Node.o: $(SRCDIR)/Node/Node.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/RailNetwork/RailNetwork.o: $(SRCDIR)/RailNetwork/RailNetwork.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/Train/Train.o: $(SRCDIR)/Train/Train.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/Event/Event.o: $(SRCDIR)/Event/Event.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/TrainFactory/TrainFactory.o: $(SRCDIR)/TrainFactory/TrainFactory.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/DijkstraPathfinding/DijkstraPathfinding.o: $(SRCDIR)/DijkstraPathfinding/DijkstraPathfinding.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/InputHandler/InputHandler.o: $(SRCDIR)/InputHandler/InputHandler.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/OutputManager/OutputManager.o: $(SRCDIR)/OutputManager/OutputManager.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/Simulation/Simulation.o: $(SRCDIR)/Simulation/Simulation.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/FileOutputObserver/FileOutputObserver.o: $(SRCDIR)/FileOutputObserver/FileOutputObserver.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/GraphExporter/GraphExporter.o: $(SRCDIR)/GraphExporter/GraphExporter.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
+
+$(OBJDIR)/TerminalAnimDisplay/TerminalAnimDisplay.o: $(SRCDIR)/TerminalAnimDisplay/TerminalAnimDisplay.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@
 
@@ -89,7 +182,8 @@ TESTS = $(BINDIR)/NodeTest \
 		$(BINDIR)/IntegrationTest \
 		$(BINDIR)/EdgeCaseTest \
 		$(BINDIR)/CombinationTest \
-		$(BINDIR)/EndToEndTest
+		$(BINDIR)/EndToEndTest \
+		$(BINDIR)/InputComboTest
 
 test: $(TESTS)
 	@echo ""
@@ -105,30 +199,31 @@ test: $(TESTS)
 	@./$(BINDIR)/EdgeCaseTest || exit 1
 	@./$(BINDIR)/CombinationTest || exit 1
 	@./$(BINDIR)/EndToEndTest || exit 1
+	@./$(BINDIR)/InputComboTest || exit 1
 
 $(BINDIR)/NodeTest: $(TESTDIR)/NodeTest.cpp $(OBJDIR)/Node/Node.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/RailNetworkTest: $(TESTDIR)/RailNetworkTest.cpp \
 	$(OBJDIR)/Node/Node.o $(OBJDIR)/RailNetwork/RailNetwork.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/TrainTest: $(TESTDIR)/TrainTest.cpp \
 	$(OBJDIR)/Train/Train.o $(OBJDIR)/Node/Node.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/EventTest: $(TESTDIR)/EventTest.cpp $(OBJDIR)/Event/Event.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/DijkstraTest: $(TESTDIR)/DijkstraTest.cpp \
 	$(OBJDIR)/DijkstraPathfinding/DijkstraPathfinding.o \
 	$(OBJDIR)/RailNetwork/RailNetwork.o $(OBJDIR)/Node/Node.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/InputHandlerTest: $(TESTDIR)/InputHandlerTest.cpp \
 	$(OBJDIR)/InputHandler/InputHandler.o \
@@ -136,40 +231,56 @@ $(BINDIR)/InputHandlerTest: $(TESTDIR)/InputHandlerTest.cpp \
 	$(OBJDIR)/Event/Event.o $(OBJDIR)/Train/Train.o \
 	$(OBJDIR)/TrainFactory/TrainFactory.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/TrainFactoryTest: $(TESTDIR)/TrainFactoryTest.cpp \
 	$(OBJDIR)/TrainFactory/TrainFactory.o $(OBJDIR)/Train/Train.o \
 	$(OBJDIR)/Node/Node.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/OutputManagerTest: $(TESTDIR)/OutputManagerTest.cpp \
 	$(OBJDIR)/OutputManager/OutputManager.o \
 	$(OBJDIR)/Train/Train.o $(OBJDIR)/Node/Node.o \
 	$(OBJDIR)/Event/Event.o $(OBJDIR)/RailNetwork/RailNetwork.o
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
-# Integration test needs all objects except main.o
-LIB_OBJS = $(filter-out $(OBJDIR)/main.o, $(OBJS))
+# All objects except main.o
+LIB_OBJS	= $(OBJDIR)/Node/Node.o \
+			  $(OBJDIR)/RailNetwork/RailNetwork.o \
+			  $(OBJDIR)/Train/Train.o \
+			  $(OBJDIR)/Event/Event.o \
+			  $(OBJDIR)/TrainFactory/TrainFactory.o \
+			  $(OBJDIR)/DijkstraPathfinding/DijkstraPathfinding.o \
+			  $(OBJDIR)/InputHandler/InputHandler.o \
+			  $(OBJDIR)/OutputManager/OutputManager.o \
+			  $(OBJDIR)/Simulation/Simulation.o \
+			  $(OBJDIR)/FileOutputObserver/FileOutputObserver.o \
+			  $(OBJDIR)/GraphExporter/GraphExporter.o \
+			  $(OBJDIR)/TerminalAnimDisplay/TerminalAnimDisplay.o
 
 $(BINDIR)/IntegrationTest: $(TESTDIR)/IntegrationTest.cpp $(LIB_OBJS)
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/EdgeCaseTest: $(TESTDIR)/EdgeCaseTest.cpp $(LIB_OBJS)
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
 $(BINDIR)/CombinationTest: $(TESTDIR)/CombinationTest.cpp $(LIB_OBJS)
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) $(INC) -I$(TESTDIR) $^ -o $@
 
-# E2E test only needs TestFramework.hpp — runs ./bin/Train as subprocess
+# E2E test only needs TestFramework.hpp — runs ./bin/train_yourself as subprocess
 $(BINDIR)/EndToEndTest: $(TESTDIR)/EndToEndTest.cpp $(BINDIR)/$(NAME)
 	@mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) -I$(TESTDIR) $< -o $@
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) -I$(TESTDIR) $< -o $@
+
+# Input combo test — runs ./bin/train_yourself against all input file pairs
+$(BINDIR)/InputComboTest: $(TESTDIR)/InputComboTest.cpp $(BINDIR)/$(NAME)
+	@mkdir -p $(BINDIR)
+	$(CXX) $(CXXFLAGS) $(SANFLAGS) -I$(TESTDIR) $< -o $@
 
 # ============================================================================ #
 #                                   UTILITY                                    #
@@ -194,16 +305,7 @@ run-graph-time: all
 #                               DEPENDENCIES                                   #
 # ============================================================================ #
 
-check-deps:
-	@bash $(SCRIPTS)/check_deps.sh cli
-
-check-deps-gui:
-	@bash $(SCRIPTS)/check_deps.sh gui
-
-deps:
-	@bash $(SCRIPTS)/check_deps.sh install-cli
-
-deps-gui:
+setup:
 	@bash $(SCRIPTS)/check_deps.sh install-gui
 
 # ============================================================================ #
@@ -219,10 +321,9 @@ QMAKE := $(shell command -v qmake6 2>/dev/null \
          || echo "")
 
 bonus:
-	@bash $(SCRIPTS)/check_deps.sh gui
 	@if [ -z "$(QMAKE)" ]; then \
-		echo "\n\033[0;31m✗ qmake not found. Install Qt 6 first:\033[0m"; \
-		echo "  \033[0;36mmake deps-gui\033[0m\n"; \
+		echo "\n\033[0;31m✗ qmake not found. Install Qt first:\033[0m"; \
+		echo "  \033[0;36mmake setup\033[0m\n"; \
 		exit 1; \
 	fi
 	@echo "\nBuilding Qt GUI bonus..."
@@ -249,5 +350,5 @@ run-gui: bonus
 	fi
 
 .PHONY: all clean fclean re test run run-time run-graph run-graph-time \
-        check-deps check-deps-gui deps deps-gui \
+        setup \
         bonus bonus-clean run-animate run-multi run-gui

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A physics-based train simulation engine that models rail traffic across a config
 | **Pathfinding** | Dijkstra shortest-path (Strategy pattern) · distance or time weight mode (`--time` flag) |
 | **Per-train output** | `TrainName_HHhMM.result` file with header, estimated time, every-minute rail graph, events, actual time |
 | **Random events** | Probability-based disruptions at stations (riots, discomfort, …) inject delays |
-| **315 unit / integration tests** | Custom TestFramework, 11 suites covering nodes, networks, trains, events, pathfinding, I/O, factories, edge cases, combinations |
+| **498 unit / integration tests** | Custom TestFramework, 13 suites covering nodes, networks, trains, events, pathfinding, I/O, factories, edge cases, combinations, end-to-end, input combos |
 | **3 design patterns + 6 principles** | Strategy, Factory, Observer · KISS, DRY, Encapsulation, SRP, Separation of Concerns, Interface Segregation |
 | **7 UML diagrams** | Class, 3 sequence, state machine, 2 activity — PlantUML sources + PNG + SVG |
 
@@ -35,62 +35,31 @@ A physics-based train simulation engine that models rail traffic across a config
 
 ### Requirements
 
-- A C++17 compiler (`c++`, `g++`, or `clang++`)
-- `make`
-- **Qt 6** (only for the GUI bonus)
+- **C++17 compiler** (g++ >= 7 or clang++ >= 5)
+- **make**
+- **Qt >= 6.3** (for GUI bonus only)
 - Supported platforms: **macOS**, **Linux**, **WSL**
 
-### Install Dependencies
-
-The project can check and install everything it needs automatically:
+### Setup
 
 ```bash
-make deps           # check & install CLI build dependencies
-make deps-gui       # check & install CLI + Qt 6 for the GUI bonus
-make check-deps     # just check CLI deps (no install)
-make check-deps-gui # just check CLI + Qt deps (no install)
+make setup    # checks dependencies, installs missing ones (compiler, Qt)
 ```
 
-<details>
-<summary>Manual install per platform</summary>
-
-**macOS**
-```bash
-xcode-select --install   # C++ compiler & make
-brew install qt           # Qt 6 (GUI bonus only)
-```
-
-**Ubuntu / Debian / WSL**
-```bash
-sudo apt-get update && sudo apt-get install -y build-essential   # C++ & make
-sudo apt-get install -y qt6-base-dev                              # Qt 6 (GUI bonus only)
-```
-
-**Fedora**
-```bash
-sudo dnf install -y gcc-c++ make       # C++ & make
-sudo dnf install -y qt6-qtbase-devel   # Qt 6 (GUI bonus only)
-```
-
-**Arch Linux**
-```bash
-sudo pacman -S --noconfirm base-devel   # C++ & make
-sudo pacman -S --noconfirm qt6-base     # Qt 6 (GUI bonus only)
-```
-</details>
+The script detects your platform (macOS/Homebrew, Debian/Ubuntu, Fedora, Arch) and installs what's needed.
 
 ### Build & Run
 
 ```bash
 make                # build
 make run            # run with sample data
-./bin/Train --help  # show input file format
+./bin/train_yourself --help  # show input file format
 
 # Or supply your own files
-./bin/Train path/to/network.txt path/to/trains.txt
+./bin/train_yourself path/to/network.txt path/to/trains.txt
 
 # Optimise route by travel time instead of distance
-./bin/Train path/to/network.txt path/to/trains.txt --time
+./bin/train_yourself path/to/network.txt path/to/trains.txt --time
 
 # Terminal animation
 make run-animate
@@ -99,7 +68,7 @@ make run-animate
 make run-multi
 
 # Graph export (Graphviz DOT + auto-render PNG/SVG)
-./bin/Train network.txt trains.txt --graph output/network.dot
+./bin/train_yourself network.txt trains.txt --graph output/network.dot
 make run-graph    # shortcut with sample data
 
 # GUI bonus
@@ -110,10 +79,10 @@ make run-gui        # build & launch
 ### CLI Reference
 
 <details>
-<summary><code>./bin/Train --help</code> (click to expand)</summary>
+<summary><code>./bin/train_yourself --help</code> (click to expand)</summary>
 
 ```
-Usage: ./Train <network_file> <train_file> [options]
+Usage: ./train_yourself <network_file> <train_file> [options]
 
 Options:
   --time              Optimise route by travel time instead of distance
@@ -141,7 +110,7 @@ Options:
 The `--graph` flag exports the rail network and all computed train paths as a **Graphviz DOT** file:
 
 ```bash
-./bin/Train network.txt trains.txt --graph output/network.dot
+./bin/train_yourself network.txt trains.txt --graph output/network.dot
 ```
 
 - Stations are drawn as rounded boxes (city nodes highlighted in blue)
@@ -153,7 +122,7 @@ The `--graph` flag exports the rail network and all computed train paths as a **
 ### Run Tests
 
 ```bash
-make test     # 315 tests across 11 suites
+make test     # 498 tests across 13 suites
 ```
 
 ### Clean
@@ -232,7 +201,7 @@ See [docs/TECHNICAL.md](docs/TECHNICAL.md) for the full documentation index, or 
 | [Design Patterns](docs/DESIGN_PATTERNS.md) | Strategy, Factory, Observer · DI · Class Relationships · 6 Design Principles |
 | [Class Reference](docs/CLASS_REFERENCE.md) | Per-class API documentation |
 | [Diagrams](docs/DIAGRAMS.md) | 7 UML diagrams (class, state, sequence, activity) |
-| [Build & Testing](docs/BUILD_SYSTEM.md) | Makefile targets, 315 tests, CI pipeline |
+| [Build & Testing](docs/BUILD_SYSTEM.md) | Makefile targets, 498 tests, CI pipeline |
 
 ### Design Patterns
 

--- a/bonus/gui/MainWindow.cpp
+++ b/bonus/gui/MainWindow.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   MainWindow.cpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:06:28 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/03/01 16:19:44 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -484,6 +484,35 @@ void MainWindow::buildToolbar()
 
 	tb->addSeparator();
 
+	/* ── Path weight mode ── */
+	auto *pathCaption = new QLabel("  Path: ");
+	pathCaption->setStyleSheet("QLabel { color: #94a3b8; font-size: 12px; }");
+	tb->addWidget(pathCaption);
+
+	_pathWeightCombo = new QComboBox;
+	_pathWeightCombo->addItem("Distance");
+	_pathWeightCombo->addItem("Time");
+	_pathWeightCombo->setCurrentIndex(0);
+	_pathWeightCombo->setToolTip(
+		"Pathfinding weight:\n"
+		"  Distance — shortest path by km\n"
+		"  Time     — fastest path (accounts for speed limits)");
+	_pathWeightCombo->setFixedWidth(100);
+	_pathWeightCombo->setStyleSheet(
+		"QComboBox { background: #1e293b; color: #e0e0e0; "
+		"border: 1px solid #334155; border-radius: 4px; padding: 4px 8px; "
+		"font-size: 12px; }"
+		"QComboBox:focus { border-color: #533483; }"
+		"QComboBox::drop-down { border: none; }"
+		"QComboBox::down-arrow { image: none; }"
+		"QComboBox QAbstractItemView { background: #1e293b; color: #e0e0e0; "
+		"selection-background-color: #533483; border: 1px solid #334155; }");
+	connect(_pathWeightCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+			this, [this](int idx) { _useTimeWeight = (idx == 1); });
+	tb->addWidget(_pathWeightCombo);
+
+	tb->addSeparator();
+
 	/* ── Speed slider ── */
 	auto *spdCaption = new QLabel("  Speed: ");
 	spdCaption->setStyleSheet("QLabel { color: #94a3b8; font-size: 12px; }");
@@ -688,11 +717,17 @@ void MainWindow::scanPresetFiles()
 {
 	/* Resolve project root from the binary location so that preset
 	   scanning works regardless of how the app was launched (open,
-	   double-click, terminal, etc.). */
+	   double-click, terminal, etc.).
+	   On macOS the binary lives inside a .app bundle:
+	       bin/TrainGUI.app/Contents/MacOS/TrainGUI  →  4 cdUp()
+	   On Linux the binary is a plain ELF:
+	       bin/TrainGUI                               →  1 cdUp()  */
 	QDir root(QCoreApplication::applicationDirPath());
+#ifdef Q_OS_MACOS
 	root.cdUp(); // MacOS -> Contents
 	root.cdUp(); // Contents -> TrainGUI.app
 	root.cdUp(); // TrainGUI.app -> bin
+#endif
 	root.cdUp(); // bin -> project root
 
 	/* Scan network presets (skip files with known-bad names) */

--- a/bonus/gui/MainWindow.hpp
+++ b/bonus/gui/MainWindow.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   MainWindow.hpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:06:28 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/03/01 16:19:44 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -138,6 +138,7 @@ class MainWindow : public QMainWindow
 	QLabel *_speedLabel;
 	QSpinBox *_runsSpinBox;
 	QCheckBox *_animateCheck;
+	QComboBox *_pathWeightCombo;
 
 	/* ─── Preset combos ─────────────────────────────────────────────── */
 	QComboBox *_presetNetworkCombo;

--- a/bonus/gui/Makefile
+++ b/bonus/gui/Makefile
@@ -37,7 +37,7 @@ MOVE          = mv -f
 TAR           = tar -cf
 COMPRESS      = gzip -9f
 DISTNAME      = TrainGUI1.0.0
-DISTDIR = /Users/abaiao-r/Module_05_Train_yourself/objs/gui/TrainGUI1.0.0
+DISTDIR = /Users/ctw03933/Module_05_Train_yourself/objs/gui/TrainGUI1.0.0
 LINK          = /Library/Developer/CommandLineTools/usr/bin/clang++
 LFLAGS        = -stdlib=libc++ -headerpad_max_install_names $(EXPORT_ARCH_ARGS) -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -mmacosx-version-min=14.0 -Wl,-rpath,@executable_path/../Frameworks -Wl,-rpath,/opt/homebrew/lib
 LIBS          = $(SUBLIBS) -F/opt/homebrew/lib -framework QtWidgets -framework QtGui -framework AppKit -framework ImageIO -framework Metal -framework QtCore -framework IOKit -framework DiskArbitration -framework UniformTypeIdentifiers -framework OpenGL   
@@ -490,12 +490,12 @@ TARGET        = ../../bin/TrainGUI.app/Contents/MacOS/TrainGUI
 EXPORT_QMAKE_MAC_SDK = macosx
 EXPORT_QMAKE_MAC_SDK_VERSION = 26.2
 EXPORT_QMAKE_XCODE_DEVELOPER_PATH = /Library/Developer/CommandLineTools
-EXPORT__QMAKE_STASH_ = /Users/abaiao-r/Module_05_Train_yourself/bonus/gui/.qmake.stash
+EXPORT__QMAKE_STASH_ = /Users/ctw03933/Module_05_Train_yourself/bonus/gui/.qmake.stash
 EXPORT_VALID_ARCHS = arm64
 EXPORT_DEFAULT_ARCHS = arm64
 EXPORT_ARCHS = $(filter $(EXPORT_VALID_ARCHS), $(if $(ARCHS), $(ARCHS), $(if $(EXPORT_DEFAULT_ARCHS), $(EXPORT_DEFAULT_ARCHS), $(EXPORT_VALID_ARCHS))))
 EXPORT_ARCH_ARGS = $(foreach arch, $(if $(EXPORT_ARCHS), $(EXPORT_ARCHS), $(EXPORT_VALID_ARCHS)), -arch $(arch))
-EXPORT__PRO_FILE_ = /Users/abaiao-r/Module_05_Train_yourself/bonus/gui/bonus.pro
+EXPORT__PRO_FILE_ = /Users/ctw03933/Module_05_Train_yourself/bonus/gui/bonus.pro
 
 
 include /opt/homebrew/share/qt/mkspecs/features/mac/sdk.mk
@@ -1318,6 +1318,8 @@ compiler_moc_header_make_all: ../../objs/gui/moc/moc_MainWindow.cpp ../../objs/g
 compiler_moc_header_clean:
 	-$(DEL_FILE) ../../objs/gui/moc/moc_MainWindow.cpp ../../objs/gui/moc/moc_NetworkScene.cpp ../../objs/gui/moc/moc_SimulationWorker.cpp ../../objs/gui/moc/moc_SimDashboard.cpp
 ../../objs/gui/moc/moc_MainWindow.cpp: MainWindow.hpp \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QCheckBox \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qcheckbox.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QComboBox \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qcombobox.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QGraphicsView \
@@ -1332,6 +1334,10 @@ compiler_moc_header_clean:
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qpushbutton.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QSlider \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qslider.h \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QSpinBox \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qspinbox.h \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QSplitter \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qsplitter.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QTextEdit \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qtextedit.h \
 		/opt/homebrew/lib/QtCore.framework/Headers/QThread \
@@ -1365,7 +1371,7 @@ compiler_moc_header_clean:
 		../../src/Train/Train.hpp \
 		../../objs/gui/moc/moc_predefs.h \
 		/opt/homebrew/share/qt/libexec/moc
-	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/abaiao-r/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/abaiao-r/Module_05_Train_yourself/bonus/gui -I/Users/abaiao-r/Module_05_Train_yourself/src/Edge -I/Users/abaiao-r/Module_05_Train_yourself/src/Node -I/Users/abaiao-r/Module_05_Train_yourself/src/RailNetwork -I/Users/abaiao-r/Module_05_Train_yourself/src/Train -I/Users/abaiao-r/Module_05_Train_yourself/src/Event -I/Users/abaiao-r/Module_05_Train_yourself/src/TrainFactory -I/Users/abaiao-r/Module_05_Train_yourself/src/IPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/InputHandler -I/Users/abaiao-r/Module_05_Train_yourself/src/OutputManager -I/Users/abaiao-r/Module_05_Train_yourself/src/Simulation -I/Users/abaiao-r/Module_05_Train_yourself/src/ISimulationObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/FileOutputObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/GraphExporter -I/Users/abaiao-r/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib MainWindow.hpp -o ../../objs/gui/moc/moc_MainWindow.cpp
+	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/ctw03933/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/ctw03933/Module_05_Train_yourself/bonus/gui -I/Users/ctw03933/Module_05_Train_yourself/src/Edge -I/Users/ctw03933/Module_05_Train_yourself/src/Node -I/Users/ctw03933/Module_05_Train_yourself/src/RailNetwork -I/Users/ctw03933/Module_05_Train_yourself/src/Train -I/Users/ctw03933/Module_05_Train_yourself/src/Event -I/Users/ctw03933/Module_05_Train_yourself/src/TrainFactory -I/Users/ctw03933/Module_05_Train_yourself/src/IPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/InputHandler -I/Users/ctw03933/Module_05_Train_yourself/src/OutputManager -I/Users/ctw03933/Module_05_Train_yourself/src/Simulation -I/Users/ctw03933/Module_05_Train_yourself/src/ISimulationObserver -I/Users/ctw03933/Module_05_Train_yourself/src/FileOutputObserver -I/Users/ctw03933/Module_05_Train_yourself/src/GraphExporter -I/Users/ctw03933/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib MainWindow.hpp -o ../../objs/gui/moc/moc_MainWindow.cpp
 
 ../../objs/gui/moc/moc_NetworkScene.cpp: NetworkScene.hpp \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QGraphicsEllipseItem \
@@ -1390,7 +1396,7 @@ compiler_moc_header_clean:
 		/opt/homebrew/lib/QtCore.framework/Headers/qmutex.h \
 		../../objs/gui/moc/moc_predefs.h \
 		/opt/homebrew/share/qt/libexec/moc
-	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/abaiao-r/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/abaiao-r/Module_05_Train_yourself/bonus/gui -I/Users/abaiao-r/Module_05_Train_yourself/src/Edge -I/Users/abaiao-r/Module_05_Train_yourself/src/Node -I/Users/abaiao-r/Module_05_Train_yourself/src/RailNetwork -I/Users/abaiao-r/Module_05_Train_yourself/src/Train -I/Users/abaiao-r/Module_05_Train_yourself/src/Event -I/Users/abaiao-r/Module_05_Train_yourself/src/TrainFactory -I/Users/abaiao-r/Module_05_Train_yourself/src/IPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/InputHandler -I/Users/abaiao-r/Module_05_Train_yourself/src/OutputManager -I/Users/abaiao-r/Module_05_Train_yourself/src/Simulation -I/Users/abaiao-r/Module_05_Train_yourself/src/ISimulationObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/FileOutputObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/GraphExporter -I/Users/abaiao-r/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib NetworkScene.hpp -o ../../objs/gui/moc/moc_NetworkScene.cpp
+	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/ctw03933/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/ctw03933/Module_05_Train_yourself/bonus/gui -I/Users/ctw03933/Module_05_Train_yourself/src/Edge -I/Users/ctw03933/Module_05_Train_yourself/src/Node -I/Users/ctw03933/Module_05_Train_yourself/src/RailNetwork -I/Users/ctw03933/Module_05_Train_yourself/src/Train -I/Users/ctw03933/Module_05_Train_yourself/src/Event -I/Users/ctw03933/Module_05_Train_yourself/src/TrainFactory -I/Users/ctw03933/Module_05_Train_yourself/src/IPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/InputHandler -I/Users/ctw03933/Module_05_Train_yourself/src/OutputManager -I/Users/ctw03933/Module_05_Train_yourself/src/Simulation -I/Users/ctw03933/Module_05_Train_yourself/src/ISimulationObserver -I/Users/ctw03933/Module_05_Train_yourself/src/FileOutputObserver -I/Users/ctw03933/Module_05_Train_yourself/src/GraphExporter -I/Users/ctw03933/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib NetworkScene.hpp -o ../../objs/gui/moc/moc_NetworkScene.cpp
 
 ../../objs/gui/moc/moc_SimulationWorker.cpp: SimulationWorker.hpp \
 		/opt/homebrew/lib/QtCore.framework/Headers/QObject \
@@ -1403,7 +1409,7 @@ compiler_moc_header_clean:
 		/opt/homebrew/lib/QtCore.framework/Headers/qvector.h \
 		../../objs/gui/moc/moc_predefs.h \
 		/opt/homebrew/share/qt/libexec/moc
-	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/abaiao-r/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/abaiao-r/Module_05_Train_yourself/bonus/gui -I/Users/abaiao-r/Module_05_Train_yourself/src/Edge -I/Users/abaiao-r/Module_05_Train_yourself/src/Node -I/Users/abaiao-r/Module_05_Train_yourself/src/RailNetwork -I/Users/abaiao-r/Module_05_Train_yourself/src/Train -I/Users/abaiao-r/Module_05_Train_yourself/src/Event -I/Users/abaiao-r/Module_05_Train_yourself/src/TrainFactory -I/Users/abaiao-r/Module_05_Train_yourself/src/IPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/InputHandler -I/Users/abaiao-r/Module_05_Train_yourself/src/OutputManager -I/Users/abaiao-r/Module_05_Train_yourself/src/Simulation -I/Users/abaiao-r/Module_05_Train_yourself/src/ISimulationObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/FileOutputObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/GraphExporter -I/Users/abaiao-r/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib SimulationWorker.hpp -o ../../objs/gui/moc/moc_SimulationWorker.cpp
+	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/ctw03933/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/ctw03933/Module_05_Train_yourself/bonus/gui -I/Users/ctw03933/Module_05_Train_yourself/src/Edge -I/Users/ctw03933/Module_05_Train_yourself/src/Node -I/Users/ctw03933/Module_05_Train_yourself/src/RailNetwork -I/Users/ctw03933/Module_05_Train_yourself/src/Train -I/Users/ctw03933/Module_05_Train_yourself/src/Event -I/Users/ctw03933/Module_05_Train_yourself/src/TrainFactory -I/Users/ctw03933/Module_05_Train_yourself/src/IPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/InputHandler -I/Users/ctw03933/Module_05_Train_yourself/src/OutputManager -I/Users/ctw03933/Module_05_Train_yourself/src/Simulation -I/Users/ctw03933/Module_05_Train_yourself/src/ISimulationObserver -I/Users/ctw03933/Module_05_Train_yourself/src/FileOutputObserver -I/Users/ctw03933/Module_05_Train_yourself/src/GraphExporter -I/Users/ctw03933/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib SimulationWorker.hpp -o ../../objs/gui/moc/moc_SimulationWorker.cpp
 
 ../../objs/gui/moc/moc_SimDashboard.cpp: SimDashboard.hpp \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QTextEdit \
@@ -1419,7 +1425,7 @@ compiler_moc_header_clean:
 		/opt/homebrew/lib/QtCore.framework/Headers/qstring.h \
 		../../objs/gui/moc/moc_predefs.h \
 		/opt/homebrew/share/qt/libexec/moc
-	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/abaiao-r/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/abaiao-r/Module_05_Train_yourself/bonus/gui -I/Users/abaiao-r/Module_05_Train_yourself/src/Edge -I/Users/abaiao-r/Module_05_Train_yourself/src/Node -I/Users/abaiao-r/Module_05_Train_yourself/src/RailNetwork -I/Users/abaiao-r/Module_05_Train_yourself/src/Train -I/Users/abaiao-r/Module_05_Train_yourself/src/Event -I/Users/abaiao-r/Module_05_Train_yourself/src/TrainFactory -I/Users/abaiao-r/Module_05_Train_yourself/src/IPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/abaiao-r/Module_05_Train_yourself/src/InputHandler -I/Users/abaiao-r/Module_05_Train_yourself/src/OutputManager -I/Users/abaiao-r/Module_05_Train_yourself/src/Simulation -I/Users/abaiao-r/Module_05_Train_yourself/src/ISimulationObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/FileOutputObserver -I/Users/abaiao-r/Module_05_Train_yourself/src/GraphExporter -I/Users/abaiao-r/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib SimDashboard.hpp -o ../../objs/gui/moc/moc_SimDashboard.cpp
+	/opt/homebrew/share/qt/libexec/moc $(DEFINES) --include /Users/ctw03933/Module_05_Train_yourself/objs/gui/moc/moc_predefs.h -I/opt/homebrew/share/qt/mkspecs/macx-clang -I/Users/ctw03933/Module_05_Train_yourself/bonus/gui -I/Users/ctw03933/Module_05_Train_yourself/src/Edge -I/Users/ctw03933/Module_05_Train_yourself/src/Node -I/Users/ctw03933/Module_05_Train_yourself/src/RailNetwork -I/Users/ctw03933/Module_05_Train_yourself/src/Train -I/Users/ctw03933/Module_05_Train_yourself/src/Event -I/Users/ctw03933/Module_05_Train_yourself/src/TrainFactory -I/Users/ctw03933/Module_05_Train_yourself/src/IPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/DijkstraPathfinding -I/Users/ctw03933/Module_05_Train_yourself/src/InputHandler -I/Users/ctw03933/Module_05_Train_yourself/src/OutputManager -I/Users/ctw03933/Module_05_Train_yourself/src/Simulation -I/Users/ctw03933/Module_05_Train_yourself/src/ISimulationObserver -I/Users/ctw03933/Module_05_Train_yourself/src/FileOutputObserver -I/Users/ctw03933/Module_05_Train_yourself/src/GraphExporter -I/Users/ctw03933/Module_05_Train_yourself/src/TerminalAnimDisplay -I/opt/homebrew/lib/QtWidgets.framework/Headers -I/opt/homebrew/lib/QtGui.framework/Headers -I/opt/homebrew/lib/QtCore.framework/Headers -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -I/Library/Developer/CommandLineTools/usr/lib/clang/17/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/usr/include -F/opt/homebrew/lib SimDashboard.hpp -o ../../objs/gui/moc/moc_SimDashboard.cpp
 
 compiler_moc_objc_header_make_all:
 compiler_moc_objc_header_clean:
@@ -1520,7 +1526,11 @@ compiler_clean: compiler_moc_predefs_clean compiler_moc_header_clean
 
 ../../objs/gui/main.o: main.cpp /opt/homebrew/lib/QtWidgets.framework/Headers/QApplication \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qapplication.h \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QStyleFactory \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qstylefactory.h \
 		MainWindow.hpp \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QCheckBox \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qcheckbox.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QComboBox \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qcombobox.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QGraphicsView \
@@ -1535,6 +1545,10 @@ compiler_clean: compiler_moc_predefs_clean compiler_moc_header_clean
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qpushbutton.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QSlider \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qslider.h \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QSpinBox \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qspinbox.h \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QSplitter \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qsplitter.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QTextEdit \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qtextedit.h \
 		/opt/homebrew/lib/QtCore.framework/Headers/QThread \
@@ -1569,6 +1583,8 @@ compiler_clean: compiler_moc_predefs_clean compiler_moc_header_clean
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o ../../objs/gui/main.o main.cpp
 
 ../../objs/gui/MainWindow.o: MainWindow.cpp MainWindow.hpp \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QCheckBox \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qcheckbox.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QComboBox \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qcombobox.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QGraphicsView \
@@ -1583,6 +1599,10 @@ compiler_clean: compiler_moc_predefs_clean compiler_moc_header_clean
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qpushbutton.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QSlider \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qslider.h \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QSpinBox \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qspinbox.h \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/QSplitter \
+		/opt/homebrew/lib/QtWidgets.framework/Headers/qsplitter.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QTextEdit \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qtextedit.h \
 		/opt/homebrew/lib/QtCore.framework/Headers/QThread \
@@ -1625,7 +1645,6 @@ compiler_clean: compiler_moc_predefs_clean compiler_moc_header_clean
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QDockWidget \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qdockwidget.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QDoubleSpinBox \
-		/opt/homebrew/lib/QtWidgets.framework/Headers/qspinbox.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QFileDialog \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qfiledialog.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QFormLayout \
@@ -1648,9 +1667,6 @@ compiler_clean: compiler_moc_predefs_clean compiler_moc_header_clean
 		/opt/homebrew/lib/QtCore.framework/Headers/qregularexpression.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QScrollArea \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qscrollarea.h \
-		/opt/homebrew/lib/QtWidgets.framework/Headers/QSpinBox \
-		/opt/homebrew/lib/QtWidgets.framework/Headers/QSplitter \
-		/opt/homebrew/lib/QtWidgets.framework/Headers/qsplitter.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QStatusBar \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/qstatusbar.h \
 		/opt/homebrew/lib/QtWidgets.framework/Headers/QTabWidget \
@@ -1741,7 +1757,8 @@ compiler_clean: compiler_moc_predefs_clean compiler_moc_header_clean
 		../../src/Simulation/Simulation.hpp \
 		../../src/FileOutputObserver/FileOutputObserver.hpp \
 		../../src/ISimulationObserver/ISimulationObserver.hpp \
-		../../src/OutputManager/OutputManager.hpp
+		../../src/OutputManager/OutputManager.hpp \
+		../../src/TrainFactory/TrainFactory.hpp
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o ../../objs/gui/SimulationWorker.o SimulationWorker.cpp
 
 ../../objs/gui/SimDashboard.o: SimDashboard.cpp SimDashboard.hpp \

--- a/bonus/gui/main.cpp
+++ b/bonus/gui/main.cpp
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: abaiao-r <abaiao-r@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/22 18:30:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 10:21:12 by abaiao-r         ###   ########.fr       */
+/*   Updated: 2026/03/01 14:11:37 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <QApplication>
+#include <QStyleFactory>
 #include "MainWindow.hpp"
 
 int main(int argc, char *argv[])
@@ -18,6 +19,10 @@ int main(int argc, char *argv[])
 QApplication app(argc, argv);
 app.setApplicationName("Train Simulation");
 app.setOrganizationName("42");
+
+/* Use Fusion style on all platforms so the dark stylesheet
+   renders identically (macOS native style ignores some properties). */
+app.setStyle(QStyleFactory::create("Fusion"));
 
 MainWindow win;
 win.resize(1200, 800);

--- a/docs/BONUS_ANIMATE.md
+++ b/docs/BONUS_ANIMATE.md
@@ -10,13 +10,13 @@ A live full-screen terminal dashboard that visualises the simulation in real tim
 
 ```bash
 # Run with live animation
-./bin/Train network.txt trains.txt --animate
+./bin/train_yourself network.txt trains.txt --animate
 
 # Combine with time routing
-./bin/Train network.txt trains.txt --time --animate
+./bin/train_yourself network.txt trains.txt --time --animate
 
 # Combine with multi-run (animation plays first run only)
-./bin/Train network.txt trains.txt --animate --runs 100
+./bin/train_yourself network.txt trains.txt --animate --runs 100
 
 # Shortcut
 make run-animate

--- a/docs/BONUS_GUI.md
+++ b/docs/BONUS_GUI.md
@@ -46,8 +46,8 @@ An interactive graphical application built with Qt 6 for creating, editing, and 
 ### Build & Launch
 
 ```bash
-# Check / install Qt 6 dependencies
-make deps-gui
+# Check / install dependencies (compiler + Qt >= 6.3)
+make setup
 
 # Build the GUI
 make bonus

--- a/docs/BONUS_MULTIRUN.md
+++ b/docs/BONUS_MULTIRUN.md
@@ -10,13 +10,13 @@ Run the simulation N times with different random seeds and aggregate travel-time
 
 ```bash
 # Run 1000 simulations and display statistics
-./bin/Train network.txt trains.txt --runs 1000
+./bin/train_yourself network.txt trains.txt --runs 1000
 
 # Combine with time-based routing
-./bin/Train network.txt trains.txt --time --runs 500
+./bin/train_yourself network.txt trains.txt --time --runs 500
 
 # Combine with animation (animation plays run 0 only)
-./bin/Train network.txt trains.txt --animate --runs 100
+./bin/train_yourself network.txt trains.txt --animate --runs 100
 
 # Shortcut
 make run-multi    # runs 1000 by default (editable in Makefile)

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -10,7 +10,7 @@ Plain `Makefile` with:
 - **No relink**: pattern rules produce `.o` in `objs/`, binary only re-links if objects change
 - **Compiler**: `CXX = c++` (overridable: `make CXX=g++`)
 - **Flags**: `-Wall -Wextra -Werror -std=c++17 -g`
-- **Dependency check**: `make deps` / `make deps-gui` auto-detects platform and installs missing tools
+- **Dependency check**: `make setup` auto-detects platform and installs missing tools (compiler + Qt)
 - **qmake auto-detect**: Makefile finds qmake6/qmake across macOS Homebrew and Linux system paths
 
 ---
@@ -20,7 +20,7 @@ Plain `Makefile` with:
 | Target | Description |
 |--------|-------------|
 | `make` | Build the CLI simulator |
-| `make test` | Run all 315 tests |
+| `make test` | Run all 498 tests |
 | `make run` | Run with sample data |
 | `make run-time` | Run with time-based routing |
 | `make run-animate` | Run with terminal animation |
@@ -29,10 +29,7 @@ Plain `Makefile` with:
 | `make run-graph-time` | Export graph with time-based routing |
 | `make bonus` | Build the Qt GUI (checks Qt 6 first) |
 | `make run-gui` | Build & launch the GUI |
-| `make check-deps` | Check CLI dependencies |
-| `make check-deps-gui` | Check CLI + Qt dependencies |
-| `make deps` | Auto-install CLI dependencies |
-| `make deps-gui` | Auto-install CLI + Qt dependencies |
+| `make setup` | Check & install all dependencies (compiler + Qt) |
 | `make clean` | Remove object files |
 | `make fclean` | Remove objects + binaries |
 | `make bonus-clean` | Remove GUI build artifacts |
@@ -54,32 +51,31 @@ The `scripts/check_deps.sh` script auto-detects the platform and manages depende
 
 **Usage:**
 ```bash
-make deps           # check & install CLI build dependencies
-make deps-gui       # check & install CLI + Qt 6 for the GUI bonus
-make check-deps     # just check CLI deps (no install)
-make check-deps-gui # just check CLI + Qt deps (no install)
+make setup      # check & install all dependencies (compiler, make, Qt >= 6.3)
 ```
 
 ---
 
 ## Testing
 
-**315 tests** across **11 suites**, all using the custom `TestFramework.hpp`:
+**498 tests** across **13 suites**, all using the custom `TestFramework.hpp`:
 
 | Suite | Tests | Coverage |
 |-------|------:|----------|
 | NodeTest | 5 | Construction, naming, exceptions |
 | RailNetworkTest | 14 | Graph operations, validation |
-| TrainTest | 14 | Properties, physics calculations |
+| TrainTest | 16 | Properties, physics calculations |
 | EventTest | 13 | Probability, duration, rail events |
 | DijkstraTest | 11 | Shortest path, weight modes |
 | InputHandlerTest | 28 | Parsing, validation, error handling |
-| TrainFactoryTest | 11 | Factory method, ID assignment |
+| TrainFactoryTest | 13 | Factory method, ID assignment |
 | OutputManagerTest | 5 | Formatting, file output |
 | IntegrationTest | 7 | End-to-end with .result file checks |
 | EdgeCaseTest | 9 | Boundary values, error paths |
-| CombinationTest | 198 | Exhaustive parameter combinations |
-| **Total** | **315** | |
+| CombinationTest | 315 | Exhaustive parameter combinations |
+| EndToEndTest | 26 | Subprocess binary validation, exit codes |
+| InputComboTest | 36 | All input file pairs, ASan leak checks |
+| **Total** | **498** | |
 
 ### Test Framework
 
@@ -92,7 +88,7 @@ Custom `TestFramework.hpp` provides:
 ### Running Tests
 
 ```bash
-make test     # run all 315 tests
+make test     # run all 498 tests
 ```
 
 ---

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -15,7 +15,7 @@ This is the central index for the project's technical documentation. Each topic 
 | [DESIGN_PATTERNS.md](DESIGN_PATTERNS.md) | Strategy, Factory, Observer patterns · Dependency Injection · Orthodox Canonical Form · Class Relationships (UML) · Design Principles (KISS, DRY, Encapsulation, SRP, Separation of Concerns, Interface Segregation) |
 | [CLASS_REFERENCE.md](CLASS_REFERENCE.md) | Per-class API: Node, Edge, RailNetwork, Train, TrainStatus, TrainState, TrainResult, Event, TrainFactory, InputHandler, SimulationData, Simulation, OutputManager, FileOutputObserver, GraphExporter, TerminalAnimDisplay, GUI classes |
 | [DIAGRAMS.md](DIAGRAMS.md) | All 7 UML diagrams: class, state machine, 2 activity, 3 sequence — with rendered PNGs and PlantUML sources |
-| [BUILD_SYSTEM.md](BUILD_SYSTEM.md) | Makefile targets, dependency management (cross-platform), testing (315 tests / 11 suites), CI pipeline |
+| [BUILD_SYSTEM.md](BUILD_SYSTEM.md) | Makefile targets, dependency management (cross-platform), testing (498 tests / 13 suites), CI pipeline |
 
 ### Bonus Features
 
@@ -49,7 +49,7 @@ This is the central index for the project's technical documentation. Each topic 
 
 ```bash
 make            # build CLI
-make test       # 315 tests
-make bonus      # build GUI (Qt 6)
-make deps-gui   # auto-install all dependencies
+make test       # 498 tests
+make bonus      # build GUI (Qt >= 6.3)
+make setup      # auto-install all dependencies
 ```

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -86,6 +86,19 @@ install_hint_qt() {
     esac
 }
 
+install_hint_graphviz() {
+    case "$OS" in
+        macos) echo "  Run: ${CYAN}brew install graphviz${NC}" ;;
+        *)
+            case "$DISTRO" in
+                debian) echo "  Run: ${CYAN}sudo apt-get update && sudo apt-get install -y graphviz${NC}" ;;
+                fedora) echo "  Run: ${CYAN}sudo dnf install -y graphviz${NC}" ;;
+                arch)   echo "  Run: ${CYAN}sudo pacman -S --noconfirm graphviz${NC}" ;;
+                *)      echo "  Install graphviz for your distribution" ;;
+            esac ;;
+    esac
+}
+
 install_hint_brew() {
     echo "  Run: ${CYAN}/bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"${NC}"
 }
@@ -98,7 +111,7 @@ try_install_compiler() {
             if ! xcode-select -p &>/dev/null; then
                 warn "Xcode Command Line Tools required. A system dialog may appear."
                 xcode-select --install 2>/dev/null || true
-                printf "\n${YELLOW}  After the installation dialog completes, re-run: make deps${NC}\n\n"
+                printf "\n${YELLOW}  After the installation dialog completes, re-run: make setup${NC}\n\n"
                 exit 1
             fi ;;
         *)
@@ -180,6 +193,51 @@ try_install_qt() {
     esac
 }
 
+try_install_graphviz() {
+    info "Attempting to install Graphviz..."
+    case "$OS" in
+        macos)
+            if ! command -v brew &>/dev/null; then
+                fail "Homebrew is not installed (needed to install Graphviz on macOS)."
+                echo -e "$(install_hint_brew)\n"
+                echo -e "$(install_hint_graphviz)\n"
+                return 1
+            fi
+            brew install graphviz ;;
+        *)
+            case "$DISTRO" in
+                debian)
+                    if command -v sudo &>/dev/null; then
+                        sudo apt-get update -qq && sudo apt-get install -y graphviz
+                    else
+                        fail "sudo not available."
+                        echo -e "$(install_hint_graphviz)\n"
+                        return 1
+                    fi ;;
+                fedora)
+                    if command -v sudo &>/dev/null; then
+                        sudo dnf install -y graphviz
+                    else
+                        fail "sudo not available."
+                        echo -e "$(install_hint_graphviz)\n"
+                        return 1
+                    fi ;;
+                arch)
+                    if command -v sudo &>/dev/null; then
+                        sudo pacman -S --noconfirm graphviz
+                    else
+                        fail "sudo not available."
+                        echo -e "$(install_hint_graphviz)\n"
+                        return 1
+                    fi ;;
+                *)
+                    fail "Unknown distro — cannot auto-install."
+                    echo -e "$(install_hint_graphviz)\n"
+                    return 1 ;;
+            esac ;;
+    esac
+}
+
 # ── Locate qmake (exported for Makefile) ─────────────────────────────────────
 find_qmake() {
     # Try common names/paths in order of preference
@@ -233,41 +291,79 @@ check_cli() {
 # ═══════════════════════════════════════════════════════════════════════════════
 #  CHECK / INSTALL — Qt 6 + qmake
 # ═══════════════════════════════════════════════════════════════════════════════
+MIN_QT="6.3"
+
+# Compare two dot-separated version strings: returns 0 if $1 >= $2
+version_ge() {
+    local IFS=.
+    local i a=($1) b=($2)
+    for ((i = 0; i < ${#b[@]}; i++)); do
+        local va=${a[i]:-0} vb=${b[i]:-0}
+        if ((va > vb)); then return 0; fi
+        if ((va < vb)); then return 1; fi
+    done
+    return 0
+}
+
 check_gui() {
-    printf "\n${BOLD}── Qt 6 (for GUI bonus) ──${NC}\n"
+    printf "\n${BOLD}── Qt 6 (for GUI bonus) — minimum ${MIN_QT} ──${NC}\n"
 
     local qm
     if qm="$(find_qmake)"; then
         ok "qmake found  —  $qm"
-        # Verify it's Qt 6
         local ver
         ver="$("$qm" -query QT_VERSION 2>/dev/null || echo "unknown")"
         if [[ "$ver" == 6.* ]]; then
-            ok "Qt version $ver"
+            if version_ge "$ver" "$MIN_QT"; then
+                ok "Qt version $ver  (>= $MIN_QT)"
+            else
+                fail "Qt $ver is too old — minimum required is $MIN_QT"
+                echo -e "$(install_hint_qt)\n"
+                ERRORS=$((ERRORS + 1))
+            fi
         elif [[ "$ver" == 5.* ]]; then
-            fail "qmake points to Qt $ver — Qt 6 is required"
+            fail "qmake points to Qt $ver — Qt >= $MIN_QT is required"
             echo -e "$(install_hint_qt)\n"
             ERRORS=$((ERRORS + 1))
         else
             warn "Could not determine Qt version (got: $ver)"
         fi
     else
-        fail "qmake not found — Qt 6 is required for the GUI bonus"
+        fail "qmake not found — Qt >= $MIN_QT is required for the GUI bonus"
         echo -e "$(install_hint_qt)\n"
         ERRORS=$((ERRORS + 1))
     fi
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
+#  CHECK / INSTALL — Graphviz (optional — for --graph rendering)
+# ═══════════════════════════════════════════════════════════════════════════════
+check_graphviz() {
+    printf "\n${BOLD}── Graphviz (for --graph PNG/SVG rendering) ──${NC}\n"
+
+    if command -v dot &>/dev/null; then
+        ok "dot (graphviz)  —  $(dot -V 2>&1 | head -1)"
+    else
+        warn "graphviz not found — --graph will produce .dot files but not PNG/SVG"
+        echo -e "$(install_hint_graphviz)\n"
+        GRAPHVIZ_MISSING=1
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
 #  MAIN
 # ═══════════════════════════════════════════════════════════════════════════════
+GRAPHVIZ_MISSING=0
+
 case "$MODE" in
     cli)
         check_cli
+        check_graphviz
         ;;
     gui)
         check_cli
         check_gui
+        check_graphviz
         ;;
     install-cli)
         check_cli
@@ -277,6 +373,14 @@ case "$MODE" in
             ERRORS=0
             echo ""
             check_cli
+        fi
+        check_graphviz
+        if [[ $GRAPHVIZ_MISSING -gt 0 ]]; then
+            echo ""
+            try_install_graphviz
+            GRAPHVIZ_MISSING=0
+            echo ""
+            check_graphviz
         fi
         ;;
     install-gui)
@@ -295,6 +399,14 @@ case "$MODE" in
             ERRORS=0
             echo ""
             check_gui
+        fi
+        check_graphviz
+        if [[ $GRAPHVIZ_MISSING -gt 0 ]]; then
+            echo ""
+            try_install_graphviz
+            GRAPHVIZ_MISSING=0
+            echo ""
+            check_graphviz
         fi
         ;;
     *)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 02:45:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:19:32 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/03/01 15:45:29 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@
 static void printHelp()
 {
 	std::cout
-		<< "Usage: ./Train <network_file> <train_file> [options]\n\n"
+		<< "Usage: ./train_yourself <network_file> <train_file> [options]\n\n"
 		<< "Options:\n"
 		<< "  --time              Optimise route by travel time "
 		<< "instead of distance\n"
@@ -46,7 +46,7 @@ static void printHelp()
 		<< "average travel times\n"
 		<< "  --help              Show this help message\n\n"
 		<< "=== Build targets ===\n"
-		<< "  make                Build the CLI binary (./bin/Train)\n"
+		<< "  make                Build the CLI binary (./bin/train_yourself)\n"
 		<< "  make test           Run all test suites (unit + E2E)\n"
 		<< "  make bonus          Build the Qt 6 GUI (./bin/TrainGUI)\n"
 		<< "  make run-gui        Build and launch the GUI\n"
@@ -58,7 +58,7 @@ static void printHelp()
 		<< "    input/railNetworkPrintFolder/<network>.txt\n"
 		<< "    input/trainPrintFolder/<trains>.txt\n\n"
 		<< "  Example:\n"
-		<< "    ./Train input/railNetworkPrintFolder/"
+		<< "    ./train_yourself input/railNetworkPrintFolder/"
 		<< "railNetworkPrintGood.txt \\\n"
 		<< "           input/trainPrintFolder/"
 		<< "trainPrintGood.txt\n\n"

--- a/tests/EndToEndTest.cpp
+++ b/tests/EndToEndTest.cpp
@@ -6,12 +6,12 @@
 /*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/23 13:00:00 by abaiao-r          #+#    #+#             */
-/*   Updated: 2026/02/23 15:19:32 by ctw03933         ###   ########.fr       */
+/*   Updated: 2026/03/01 15:45:29 by ctw03933         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 /**
- * End-to-End tests — runs the compiled ./bin/Train binary as a subprocess
+ * End-to-End tests — runs the compiled ./bin/train_yourself binary as a subprocess
  * and validates exit codes, stdout/stderr content, and generated output files.
  */
 
@@ -24,7 +24,7 @@
 
 #include "TestFramework.hpp"
 
-static const std::string BIN = "./bin/Train";
+static const std::string BIN = "./bin/train_yourself";
 static const std::string NET =
 	"input/railNetworkPrintFolder/railNetworkPrintGood.txt";
 static const std::string TRN = "input/trainPrintFolder/trainPrintGood.txt";

--- a/tests/InputComboTest.cpp
+++ b/tests/InputComboTest.cpp
@@ -1,0 +1,304 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   InputComboTest.cpp                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ctw03933 <ctw03933@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/01 00:30:00 by ctw03933          #+#    #+#             */
+/*   Updated: 2026/03/01 15:45:29 by ctw03933         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+/**
+ * Input-combination tests — runs ./bin/train_yourself as a subprocess against every
+ * input file pair.  Valid pairs must exit 0; bad inputs must exit non-zero.
+ * Compiled with -fsanitize=address so ASan catches any leaks or UB.
+ */
+
+#include <array>
+#include <cstdio>
+#include <string>
+
+#include "TestFramework.hpp"
+
+static const std::string BIN = "./bin/train_yourself";
+static const std::string NET = "input/railNetworkPrintFolder/";
+static const std::string TRN = "input/trainPrintFolder/";
+
+/* ---- Helper ---- */
+
+static int runExit(const std::string &cmd)
+{
+	std::string full = cmd + " >/dev/null 2>&1";
+	int status = std::system(full.c_str());
+#ifdef _WIN32
+	return status;
+#else
+	return WEXITSTATUS(status);
+#endif
+}
+
+static bool expectOk(const std::string &net, const std::string &trn,
+					 const std::string &flags, std::string &msg)
+{
+	std::string cmd = BIN + " " + NET + net + " " + TRN + trn;
+	if (!flags.empty())
+		cmd += " " + flags;
+	int ec = runExit(cmd);
+	ASSERT_EQ(0, ec, msg);
+	return true;
+}
+
+static bool expectFail(const std::string &net, const std::string &trn,
+					   std::string &msg)
+{
+	std::string cmd = BIN + " " + NET + net + " " + TRN + trn;
+	int ec = runExit(cmd);
+	ASSERT_TRUE(ec != 0, msg);
+	return true;
+}
+
+/* ======================================================================== */
+
+int main()
+{
+	Test::TestSuite suite("Input-Combo");
+
+	/* ------------------------------------------------------------------ */
+	/*  Valid pairs — must exit 0                                          */
+	/* ------------------------------------------------------------------ */
+
+	suite.run("Good network + Good trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPrintGood.txt",
+								  "trainPrintGood.txt", "", m);
+			  });
+
+	suite.run("Good network + Good trains --time",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPrintGood.txt",
+								  "trainPrintGood.txt", "--time", m);
+			  });
+
+	suite.run("Minimal network + Single train",
+			  [](std::string &m) {
+				  return expectOk("railNetworkMinimal.txt",
+								  "trainPrintSingle.txt", "", m);
+			  });
+
+	suite.run("France network + France trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkFrance.txt",
+								  "trainPrintFrance.txt", "", m);
+			  });
+
+	suite.run("Portugal network + Portugal trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPortugal.txt",
+								  "trainPrintPortugal.txt", "", m);
+			  });
+
+	suite.run("Europe network + Europe trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkEurope.txt",
+								  "trainPrintEurope.txt", "", m);
+			  });
+
+	suite.run("Lisbon Metro network + Lisbon Metro trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkLisbonMetro.txt",
+								  "trainPrintLisbonMetro.txt", "", m);
+			  });
+
+	suite.run("Paris Metro network + Paris Metro trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkParisMetro.txt",
+								  "trainPrintParisMetro.txt", "", m);
+			  });
+
+	suite.run("Good network + LateNight trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPrintGood.txt",
+								  "trainPrintLateNight.txt", "", m);
+			  });
+
+	suite.run("Good network + Midnight trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPrintGood.txt",
+								  "trainPrintMidnight.txt", "", m);
+			  });
+
+	suite.run("Disconnected network + Unreachable trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkDisconnected.txt",
+								  "trainPrintUnreachable.txt", "", m);
+			  });
+
+	suite.run("Good network + Unreachable trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPrintGood.txt",
+								  "trainPrintUnreachable.txt", "", m);
+			  });
+
+	suite.run("Good network + Empty trains",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPrintGood.txt",
+								  "trainPrintEmpty.txt", "", m);
+			  });
+
+	/* ------------------------------------------------------------------ */
+	/*  Valid pairs with flags                                             */
+	/* ------------------------------------------------------------------ */
+
+	suite.run("France --time",
+			  [](std::string &m) {
+				  return expectOk("railNetworkFrance.txt",
+								  "trainPrintFrance.txt", "--time", m);
+			  });
+
+	suite.run("Portugal --time",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPortugal.txt",
+								  "trainPrintPortugal.txt", "--time", m);
+			  });
+
+	suite.run("Europe --time",
+			  [](std::string &m) {
+				  return expectOk("railNetworkEurope.txt",
+								  "trainPrintEurope.txt", "--time", m);
+			  });
+
+	suite.run("Good --runs 3",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPrintGood.txt",
+								  "trainPrintGood.txt", "--runs 3", m);
+			  });
+
+	suite.run("France --graph",
+			  [](std::string &m) {
+				  return expectOk("railNetworkFrance.txt",
+								  "trainPrintFrance.txt",
+								  "--graph /tmp/ci_combo_test.dot", m);
+			  });
+
+	suite.run("Portugal --time --graph",
+			  [](std::string &m) {
+				  return expectOk("railNetworkPortugal.txt",
+								  "trainPrintPortugal.txt",
+								  "--time --graph /tmp/ci_combo_test2.dot",
+								  m);
+			  });
+
+	/* ------------------------------------------------------------------ */
+	/*  Bad network files — must exit non-zero                             */
+	/* ------------------------------------------------------------------ */
+
+	suite.run("BAD: Empty network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkEmpty.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: BadKeyword network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkBadKeyword.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: BadRail network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkBadRail.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: NegativeDistance network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkNegativeDistance.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: ZeroSpeed network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkZeroSpeed.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: SelfLoop network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkSelfLoop.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: UnknownNode network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkUnknownNode.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: DuplicateNode network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkDuplicateNode.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: DuplicateRail network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkDuplicateRail.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: MissingNodeName network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkMissingNodeName.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: BadEventDuration network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkBadEventDuration.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: BadEventUnit network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkBadEventUnit.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	suite.run("BAD: QuotedNames network",
+			  [](std::string &m) {
+				  return expectFail("railNetworkQuotedNames.txt",
+									"trainPrintGood.txt", m);
+			  });
+
+	/* ------------------------------------------------------------------ */
+	/*  Bad train files — must exit non-zero                               */
+	/* ------------------------------------------------------------------ */
+
+	suite.run("BAD: BadStation trains",
+			  [](std::string &m) {
+				  return expectFail("railNetworkPrintGood.txt",
+									"trainPrintBadStation.txt", m);
+			  });
+
+	suite.run("BAD: BadTime trains",
+			  [](std::string &m) {
+				  return expectFail("railNetworkPrintGood.txt",
+									"trainPrintBadTime.txt", m);
+			  });
+
+	suite.run("BAD: BadTimeFormat trains",
+			  [](std::string &m) {
+				  return expectFail("railNetworkPrintGood.txt",
+									"trainPrintBadTimeFormat.txt", m);
+			  });
+
+	suite.run("BAD: Incomplete trains",
+			  [](std::string &m) {
+				  return expectFail("railNetworkPrintGood.txt",
+									"trainPrintIncomplete.txt", m);
+			  });
+
+	return suite.summarize();
+}


### PR DESCRIPTION
## Description

This PR consolidates several build-system, dependency, and GUI improvements:

**Binary rename**
- Rename binary from `Train` to `train_yourself` across Makefile, src/main.cpp, tests, CI, README, and all docs

**Dependency management**
- Remove Docker infrastructure entirely (Dockerfile, docker-compose.yml, .dockerignore, all Makefile Docker targets)
- Restore native `check_deps.sh` with cross-platform detection (macOS/Debian/Fedora/Arch/WSL)
- Add Graphviz (`dot`) to dependency checker — check + auto-install on all platforms
- Enforce Qt >= 6.3 minimum version (required by `QMenu::addAction` overload)
- Remove valgrind from deps (project uses `-fsanitize=address`)
- Merge `setup`/`check-deps` into single `make setup` target

**GUI**
- Add Distance/Time path weight combo box to toolbar (wired to `_useTimeWeight`)

**Tests**
- Add `InputComboTest` suite (36 tests)
- Total: 498 tests across 13 suites

**Docs**
- Update test counts (315 → 498, 11 → 13 suites) in README, BUILD_SYSTEM.md, TECHNICAL.md, BONUS_GUI.md
- Fix stale `make deps`/`make check-deps` references → `make setup`
- Remove all Docker references from README

## Screenshots

N/A

## How to Test

```bash
make fclean && make all    # build
make run                   # run with sample input
make test                  # run all test suites (498 tests)
make setup                 # verify dependency checker
make bonus                 # build GUI with path weight toggle
```

## Checklist

- [x] Compiles with `make CXX=g++` and `make CXX=clang++` (zero warnings)
- [x] All tests pass (`make test`)
- [x] No memory leaks (ASan clean — project uses `-fsanitize=address`)
